### PR TITLE
fix: Detect GPU preflights by reachability, not by string match

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,8 +395,20 @@ learners within minutes:
 - **Any run entry without `--num_gpus` is advertised as "Runs now — no GPU
   needed"** and shown first, even for locked labs. So such an entry must really
   run on CPU, or carry `needs_gpu: true`. That field covers the five examples
-  that deliberately skip the deepspeed launcher; **Clawdeck does not read it
-  yet**, so those entries are still mislabelled in their UI until it does.
+  that deliberately skip the deepspeed launcher, and Clawdeck reads it as of
+  their v169.
+
+  The check for this is **reachability-based, not string-based**, and that
+  distinction is the whole difficulty. Two guard forms exist here —
+  `require_gpu()` and an inline
+  `if not torch.cuda.is_available() and ALLOW_CPU != "1"` — and mere presence
+  proves nothing, because four scripts put the inline form inside
+  `if args.model:` and default `--model` to `None`. Six manifest entries sit in
+  exactly that position and all six exit 0 on a CPU-only box. `gpu_guards()` in
+  `tests/test_clawdeck_manifest.py` therefore returns each guard with the flags
+  gating it, and treats a guard as reachable when it is unconditional **or** the
+  command passes any gating flag — over-flagging is recoverable with
+  `needs_gpu`, under-flagging ships a lie to a learner.
 
 Clawdeck **fails open**: an unreachable or malformed manifest yields zero labs,
 so the Lab tab disappears and plain compute keeps working. The flip side is that

--- a/tests/test_clawdeck_manifest.py
+++ b/tests/test_clawdeck_manifest.py
@@ -88,6 +88,90 @@ def lab_dirs_on_disk() -> set:
     return out
 
 
+def gpu_guards(src: str) -> list:
+    """
+    Every GPU preflight in a script, with the argparse flags gating each one.
+
+    TWO FORMS EXIST IN THIS REPO and both must be recognised. Keying on the
+    literal string `require_gpu()` missed the second, which Clawdeck caught:
+
+        require_gpu()                                     # the convention
+        if not torch.cuda.is_available() and \
+           os.environ.get("ALLOW_CPU") != "1":            # the inline form
+            sys.exit(1)
+
+    But presence is not the question — REACHABILITY is. All four inline guards
+    in this repo sit inside `if args.model:`, and `--model` defaults to None, so
+    a command that never passes `--model` never reaches them. Six manifest
+    entries are in exactly that position and all six exit 0 on a CPU-only box.
+    A checker that flagged mere presence would fail all six, which is precisely
+    the false-positive trap that made a bare `.cuda(` grep unusable.
+
+    So each guard is returned with the set of `args.X` names appearing in the
+    conditions enclosing it, mapped to flag spellings. A guard gated by an
+    argument the command does not pass cannot fire.
+
+    Returns:
+        list of sets of flag names, one per guard. An EMPTY set means the guard
+        is unconditional — it always fires.
+    """
+    import ast
+
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return []
+
+    guards: list = []
+    stack: list = []
+
+    def is_guard(node) -> bool:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            f = node.value.func
+            if isinstance(f, ast.Name) and f.id == "require_gpu":
+                return True
+        if isinstance(node, ast.If):
+            dumped = ast.dump(node.test)
+            if "cuda" in dumped and "is_available" in dumped:
+                return True
+        return False
+
+    def arg_flags(test) -> set:
+        out = set()
+        for n in ast.walk(test):
+            if (isinstance(n, ast.Attribute) and isinstance(n.value, ast.Name)
+                    and n.value.id == "args"):
+                out.add("--" + n.attr.replace("_", "-"))
+        return out
+
+    def walk(stmts) -> None:
+        # Takes a STATEMENT LIST, not a node. The first version took a node and
+        # recursed with walk(sub), which only ever inspected sub's CHILDREN --
+        # so a guard that was itself a statement of a block was never tested,
+        # and the whole check silently passed everything. Verified against the
+        # four inline guards, which it now finds.
+        for st in stmts:
+            if is_guard(st):
+                guards.append(set().union(*stack) if stack else set())
+                if isinstance(st, ast.If):
+                    continue              # do not descend into the guard body
+            if isinstance(st, ast.If):
+                stack.append(arg_flags(st.test))
+                walk(st.body)
+                stack.pop()
+                walk(st.orelse)
+                continue
+            for field in ("body", "orelse", "finalbody"):
+                inner = getattr(st, field, None)
+                if isinstance(inner, list):
+                    walk([x for x in inner if isinstance(x, ast.stmt)])
+            for handler in getattr(st, "handlers", None) or []:
+                walk(handler.body)
+
+    walk(tree.body)
+    return guards
+
+
 def main() -> None:
     bar = "=" * 74
     print(bar)
@@ -227,6 +311,104 @@ def main() -> None:
               implied == want,
               f"{Path(cfgs[0]).name} implies N={implied:g}; DeepSpeed asserts "
               "this at startup, so the Run button would abort")
+
+    # ---- gpu shapes Clawdeck can actually book ----------------------------
+    # MIRROR OF CLAWDECK'S MACHINE CATALOG, not a property of this repo.
+    # Clawdeck matches a lab to the cheapest machine satisfying it, and requires
+    # an EXACT GPU count, because DeepSpeed is launched with --num_gpus=N and
+    # aborts if that disagrees with the hardware. A lab whose shape no catalog
+    # entry satisfies renders as "Needs a different machine" with nothing to
+    # switch to -- a dead end, and nothing anywhere logs a word about it.
+    #
+    # count -> the largest per-GPU VRAM available at that count.
+    BOOKABLE = {1: 180, 2: 180, 4: 80, 8: 80}
+    print("\n  -- gpu shapes are bookable on Clawdeck --")
+    for lab in labs:
+        i = lab.get("id", "")
+        g = lab.get("gpu")
+        if not g:
+            continue                      # no gpu block == CPU lab, always fine
+        cnt, vram = g.get("count"), g.get("min_vram_gb")
+        check(f"{i}: gpu.count={cnt} is a bookable count {sorted(BOOKABLE)}",
+              cnt in BOOKABLE,
+              "Clawdeck books an EXACT count. 3 is a reasonable thing to write "
+              "and cannot be booked; the lab would show as 'Needs a different "
+              "machine' with no machine to switch to.")
+        if cnt in BOOKABLE:
+            check(f"{i}: {cnt} x {vram} GB exists in the catalog "
+                  f"(max {BOOKABLE[cnt]} GB at that count)",
+                  vram <= BOOKABLE[cnt],
+                  f"no Clawdeck machine offers {vram} GB per GPU at count "
+                  f"{cnt}. This is a PLATFORM CAPACITY limit, not a typo in "
+                  "your lab -- either lower the requirement or use a count "
+                  "that offers bigger cards.")
+
+    # ---- entries with no --num_gpus are advertised as needing no GPU -------
+    # Clawdeck's rule is exactly `is_cpu_only = "--num_gpus" not in cmd`, and
+    # such entries are shown FIRST, under "Runs now - no GPU needed", drawn
+    # even from locked labs. It is what a learner clicks while the machine is
+    # still installing. An entry that lands there and then needs a GPU is worse
+    # than a locked lab: the learner was told it would work.
+    #
+    # `needs_gpu: true` marks an entry that genuinely needs a GPU but cannot say
+    # so through --num_gpus, because its example deliberately does not use the
+    # deepspeed launcher (CLAUDE.md lists five such examples; using a
+    # distributed launcher where there is nothing to distribute is cargo cult,
+    # and faking one here purely to smuggle a GPU signal would be worse).
+    # CLAWDECK DOES NOT READ THIS FIELD YET -- see the note in clawdeck.yaml.
+    GPU_LAUNCHERS = ("torchrun", "accelerate launch", "mpirun",
+                     "deepspeed.init_distributed", "torch.distributed.run")
+    # Flags whose code path returns before any guard is reached.
+    CPU_SAFE_FLAGS = ("--plan", "--verify-arch", "--list-methods",
+                      "--list-models", "--dry-run")
+
+    print("\n  -- entries advertised as 'no GPU needed' really are --")
+    for lab in labs:
+        i = lab.get("id", "")
+        d = REPO / i
+        for r in lab.get("run") or []:
+            cmd = r.get("cmd", "")
+            if "--num_gpus" in cmd:
+                continue
+            label = r.get("label")
+            if r.get("needs_gpu") is True:
+                check(f"{i}: {label!r} is marked needs_gpu", True)
+                continue
+            script = next((t for t in shlex.split(cmd) if t.endswith(".py")), None)
+            if not script or not (d / script).is_file():
+                continue                  # already reported above
+            src = (d / script).read_text(errors="ignore")
+
+            found = [t for t in GPU_LAUNCHERS if t in src]
+            check(f"{i}: {label!r} launches no GPU-shaped process",
+                  not found,
+                  f"{script} references {found}; Clawdeck decides CPU-only by "
+                  "the absence of --num_gpus, so this would be advertised "
+                  "under 'Runs now - no GPU needed' and fail when clicked. "
+                  "Route it through `deepspeed --num_gpus=N`, or add "
+                  "`needs_gpu: true`.")
+
+            if any(f in cmd for f in CPU_SAFE_FLAGS):
+                continue                  # returns before any guard
+
+            passed = {t for t in shlex.split(cmd) if t.startswith("--")}
+            # Conservative: a guard counts as reachable when it is
+            # unconditional, OR when the command passes ANY of the flags that
+            # gate it. Requiring ALL of them would be the dangerous direction --
+            # `video_mme_eval.py --model X` is gated by {--model, --dry-run},
+            # passes only --model, and genuinely DOES hit the preflight. Over-
+            # flagging is recoverable with `needs_gpu`; under-flagging ships a
+            # lie to a learner.
+            reachable = [g for g in gpu_guards(src) if not g or (g & passed)]
+            gate = (sorted(reachable[0]) or "nothing - it always fires"
+                    if reachable else "")
+            check(f"{i}: {label!r} reaches no GPU preflight",
+                  not reachable,
+                  f"{script} has a GPU preflight this command can reach "
+                  f"(gated by {gate}). Clawdeck would advertise it under "
+                  "'Runs now - no GPU needed' and the learner would get the "
+                  "preflight instead. Add `needs_gpu: true`, or give it a "
+                  "real CPU path.")
 
     # ---- gpu shapes Clawdeck can actually book ----------------------------
     # MIRROR OF CLAWDECK'S MACHINE CATALOG, not a property of this repo.


### PR DESCRIPTION
Closes the blind spot Clawdeck's review found, and answers their question.

## Answer first: all six entries are genuinely CPU-safe

Every one of the four inline guards sits inside **`if args.model:`** (`video_mme_eval`'s inside `if args.model and not args.dry_run:`), and `--model` defaults to `None` in all four. No manifest command passes `--model`, so **the guard is never reached.**

Confirmed structurally *and* empirically — all six exit 0 on a CPU-only box, including the three they couldn't resolve statically:

| entry | exit |
|---|---|
| `Stream` — `stream_infer.py --frames 64` | 0 |
| `Evaluate (10 items)` — `video_mme_eval.py --limit 10` | 0 |
| `Dry run (no model)` | 0 |
| `Run duplex` — `run_duplex.py --slices 40` | 0 |
| `Ablation grid (CPU)` — `omni_eval.py` | 0 |
| `Fewer questions` — `omni_eval.py --questions 20` | 0 |

No `needs_gpu` needed on any of them.

## The durable fix

They were right that a future inline-style script was invisible. But flagging *presence* would fail all six above — the same false-positive trap that made the `.cuda(` grep unusable. **Presence isn't the question; reachability is.**

`gpu_guards()` now parses with `ast`, recognises **both** forms, and returns each guard with the argparse flags gating it:

```
train_grpo_math.py       [[], []]                    <- unconditional, always fires
stream_infer.py          [['--model']]
video_mme_eval.py        [['--dry-run', '--model']]
run_duplex.py            [['--model']]
omni_eval.py             [['--model']]
```

A guard is reachable when unconditional **or** the command passes *any* gating flag — deliberately conservative, because `video_mme_eval.py --model X` is gated by `{--model, --dry-run}`, passes only `--model`, and genuinely does hit the preflight. Over-flagging is recoverable with `needs_gpu`; under-flagging ships a lie to a learner.

## Two bugs in my own helper

Worth stating plainly:

1. **`walk()` inspected only a node's children, never the node itself** — so a guard that was a direct statement of a block was never tested and **the entire check silently passed everything**. Exactly the failure mode this suite exists to prevent, in the suite itself. Now takes a statement list.
2. The failure detail interpolated `reachable[0]` eagerly, so a *passing* entry raised `IndexError`.

Both were caught by running it, not by reading it.

## Negative controls

| Break | Caught |
|---|---|
| unconditional **inline** guard (previously invisible) | ✅ "gated by nothing - it always fires" |
| command activating a gated guard via `--model` | ✅ "gated by ['--dry-run', '--model']" |

**639 checks pass** on the real manifest. `--dry-run` rejoins `CPU_SAFE_FLAGS`, since `video_mme_eval` documents it as the CPU path.

Also records that Clawdeck reads `needs_gpu` as of v169, so it is no longer inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa