### PR TITLE
fix: Repair 20 config kwargs rejected by the pinned libraries, and gate the class

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Clawdeck lab manifest
         run: uv run tests/test_clawdeck_manifest.py
 
+      - name: Config kwargs match the installed library
+        run: uv run tests/test_config_kwargs.py
+
       - name: Every training script compiles
         run: |
           uv run --no-project python -m compileall -q \

--- a/03_huggingface/02_trl_sft/train_trl_deepspeed.py
+++ b/03_huggingface/02_trl_sft/train_trl_deepspeed.py
@@ -202,7 +202,7 @@ def get_training_arguments(
         deepspeed="ds_config.json",  # DeepSpeed configuration
         report_to=["wandb"] if use_wandb else [],
         run_name="trl-qwen-function-calling" if use_wandb else None,
-        logging_dir="./logs",
+        # logging_dir was removed in the pinned library version (removed in transformers 5.x; TensorBoard logs now live under output_dir).
         remove_unused_columns=False,  # Keep all dataset columns
         dataloader_num_workers=2,
     )

--- a/03_huggingface/06_grpo/archive/train_ds_grpo.py
+++ b/03_huggingface/06_grpo/archive/train_ds_grpo.py
@@ -83,14 +83,19 @@ training_args = GRPOConfig(
     adam_beta1=0.9,
     adam_beta2=0.99,
     weight_decay=0.1,
-    warmup_ratio=0.1,
+    # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+    # warmup_steps survives, and ratio -> steps is not a rename: the old
+    # value (0.1) was a fraction of a total step count that depends on
+    # dataset size, so it cannot be converted statically. This is a small
+    # absolute warmup; raise it for a long run.
+    warmup_steps=10,
     lr_scheduler_type="cosine",
     optim="paged_adamw_8bit",
     logging_steps=1,
     per_device_train_batch_size=1,
     gradient_accumulation_steps=1,
     num_generations=2,
-    max_prompt_length=256,
+    # max_prompt_length was removed in the pinned library version (removed from GRPOConfig in trl 1.x).
     max_completion_length=200,
     max_steps=100,
     save_steps=250,

--- a/03_huggingface/06_grpo/archive/train_ds_r1.py
+++ b/03_huggingface/06_grpo/archive/train_ds_r1.py
@@ -71,7 +71,7 @@ training_args = TrainingArguments(
     fp16=True,
     deepspeed="ds_config_zero1.json",
     report_to="none",                  # No logging clutter
-    save_safetensors=True,             # Lighter + faster saves
+    # save_safetensors was removed in transformers 5.x; safetensors is the default format.
     remove_unused_columns=False
 )
 

--- a/03_huggingface/06_grpo/archive/train_ds_sft.py
+++ b/03_huggingface/06_grpo/archive/train_ds_sft.py
@@ -77,7 +77,7 @@ training_args = TrainingArguments(
     fp16=True,
     deepspeed="ds_config_zero1.json",
     report_to="none",                  # No logging clutter
-    save_safetensors=True,             # Lighter + faster saves
+    # save_safetensors was removed in transformers 5.x; safetensors is the default format.
     remove_unused_columns=False
 )
 

--- a/03_huggingface/08_gpt_oss_lora/lora/train_ds.py
+++ b/03_huggingface/08_gpt_oss_lora/lora/train_ds.py
@@ -300,7 +300,12 @@ def train(
         max_length=2048,
 
         # Optimization settings
-        warmup_ratio=0.03,
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.03) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine_with_min_lr",
         lr_scheduler_kwargs={"min_lr_rate": 0.1},
 
@@ -316,7 +321,7 @@ def train(
 
         # Output settings
         output_dir=output_dir,
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=report_to if torch.distributed.get_rank() == 0 else [],
 
         # Hub settings - only enable if authentication is available

--- a/03_huggingface/08_gpt_oss_lora/lora/train_ds_h200.py
+++ b/03_huggingface/08_gpt_oss_lora/lora/train_ds_h200.py
@@ -205,7 +205,12 @@ def train(
         max_length=2048,
 
         # Optimization settings
-        warmup_ratio=0.03,
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.03) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine_with_min_lr",
         lr_scheduler_kwargs={"min_lr_rate": 0.1},
 
@@ -222,7 +227,7 @@ def train(
 
         # Output settings
         output_dir=output_dir,
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=report_to if torch.distributed.get_rank() == 0 else [],
 
         # Hub settings - only enable if authentication is available

--- a/03_huggingface/08_gpt_oss_lora/lora/train_ds_mistral7b.py
+++ b/03_huggingface/08_gpt_oss_lora/lora/train_ds_mistral7b.py
@@ -199,7 +199,12 @@ def train(
         max_length=2048,
 
         # Optimization settings
-        warmup_ratio=0.03,
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.03) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine_with_min_lr",
         lr_scheduler_kwargs={"min_lr_rate": 0.1},
 
@@ -214,7 +219,7 @@ def train(
 
         # Output settings
         output_dir=output_dir,
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=report_to if torch.distributed.get_rank() == 0 else [],
 
         # Hub settings - only enable if authentication is available

--- a/03_huggingface/08_gpt_oss_lora/train_ds_v1.py
+++ b/03_huggingface/08_gpt_oss_lora/train_ds_v1.py
@@ -167,7 +167,12 @@ def train(peft_model, tokenizer, dataset, output_dir: str, hf_user: str, push_to
         max_length=2048,
 
         # Optimization settings
-        warmup_ratio=0.03,
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.03) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine_with_min_lr",
         lr_scheduler_kwargs={"min_lr_rate": 0.1},
 
@@ -183,7 +188,7 @@ def train(peft_model, tokenizer, dataset, output_dir: str, hf_user: str, push_to
 
         # Output settings
         output_dir=output_dir,
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=["tensorboard"] if torch.distributed.get_rank() == 0 else [],
 
         # Hub settings - only enable if authentication is available

--- a/04_video_text/01_hf_baseline/llava_video_trainer/video_training_script.py
+++ b/04_video_text/01_hf_baseline/llava_video_trainer/video_training_script.py
@@ -904,7 +904,7 @@ This model expects {self.num_frames} frames extracted from each video. For best 
             num_train_epochs=3,
             learning_rate=5e-5,
             save_strategy="no",  # Disable all local checkpoints to save disk space
-            logging_dir="./logs",
+            # logging_dir was removed in the pinned library version (removed in transformers 5.x; TensorBoard logs now live under output_dir).
             logging_steps=10,  # Reduced logging frequency
             report_to=report_to,
             deepspeed=deepspeed_config_path,

--- a/04_video_text/01_hf_baseline/seq2seq_video_trainer/video_text_trainer.py
+++ b/04_video_text/01_hf_baseline/seq2seq_video_trainer/video_text_trainer.py
@@ -439,7 +439,7 @@ response = processor.decode(outputs[0], skip_special_tokens=True)
             num_train_epochs=3,
             learning_rate=5e-5,
             save_strategy="epoch",
-            logging_dir="./logs",
+            # logging_dir was removed in the pinned library version (removed in transformers 5.x; TensorBoard logs now live under output_dir).
             logging_steps=1,
             report_to=[],
             deepspeed=deepspeed_config_path,

--- a/04_video_text/archive/test1_train_vtt.py
+++ b/04_video_text/archive/test1_train_vtt.py
@@ -124,7 +124,7 @@ def main():
         num_train_epochs=3,
         learning_rate=5e-5,
         save_strategy="epoch",
-        logging_dir="./logs",
+        # logging_dir was removed in the pinned library version (removed in transformers 5.x; TensorBoard logs now live under output_dir).
         logging_steps=1,
         report_to=[],
         fp16=True

--- a/05_video_speech/01_longcat_omni/train_ds.py
+++ b/05_video_speech/01_longcat_omni/train_ds.py
@@ -439,7 +439,12 @@ def train(
         per_device_train_batch_size=1,  # Very small due to model size
         gradient_accumulation_steps=32,  # Large accumulation for effective batch size
         learning_rate=1e-4,
-        warmup_ratio=0.03,
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.03) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine",
 
         # Memory optimization
@@ -454,7 +459,7 @@ def train(
         save_total_limit=3,
 
         # Output settings
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=report_to if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0 else [],
 
         # Hub settings

--- a/05_video_speech/01_longcat_omni/train_ds_2xB200.py
+++ b/05_video_speech/01_longcat_omni/train_ds_2xB200.py
@@ -456,7 +456,12 @@ def train(
         per_device_train_batch_size=1,      # Minimum
         gradient_accumulation_steps=64,     # INCREASED from 32 to 64
         learning_rate=5e-5,                 # Reduced from 1e-4
-        warmup_ratio=0.05,                  # Slightly more warmup
+        # warmup_ratio was removed in transformers 5.x. Only the ABSOLUTE
+        # warmup_steps survives, and ratio -> steps is not a rename: the old
+        # value (0.05,) was a fraction of a total step count that depends on
+        # dataset size, so it cannot be converted statically. This is a small
+        # absolute warmup; raise it for a long run.
+        warmup_steps=10,
         lr_scheduler_type="cosine",
         max_grad_norm=0.5,                  # Aggressive gradient clipping
 
@@ -478,7 +483,7 @@ def train(
         load_best_model_at_end=False,
 
         # Output settings
-        overwrite_output_dir=True,
+        # overwrite_output_dir was removed in the pinned library version (removed in transformers 5.x).
         report_to=report_to if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0 else [],
 
         # Hub settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ passed on all of them. Established patterns to copy:
   (catastrophic cancellation), so exact equality is the wrong test.
 
 ```bash
-./tests/run_all.sh              # all 23 suites, no GPU, no downloads
+./tests/run_all.sh              # all 24 suites, no GPU, no downloads
 uv run tests/test_ds_configs.py # one suite
 ```
 
@@ -358,6 +358,36 @@ Two signatures worth recognising:
   the box advertising peer-to-peer it cannot perform. `nvidia-smi topo -m`
   showing `SYS` between cards is the tell; `NCCL_P2P_DISABLE=1` is the fix, at
   a real throughput cost. `tests/gpu/diagnose_nccl.sh` decides it in a minute.
+
+### Library API drift is a CI gate, not a runtime surprise
+
+`logging_dir=` is syntactically valid, so `compileall` cannot catch it — it
+fails only when `TrainingArguments` is constructed. A learner discovered exactly
+that on rented GPUs after both ranks had launched and the model had loaded.
+
+`tests/test_config_kwargs.py` parses every call to a known config constructor
+(`TrainingArguments`, `SFTConfig`, `DPOConfig`, `GRPOConfig`, `LoraConfig`, …)
+and checks each keyword against the **installed** class's signature. No GPU, no
+download — the constructors import fine on CPU, which is what makes this
+catchable at all.
+
+Run against the tree when written it found **20** rejected kwargs in 13 files,
+of which only one had been reported: `logging_dir`, `warmup_ratio`,
+`overwrite_output_dir`, `save_safetensors` and `max_prompt_length` were all
+removed by transformers 5.x / trl 1.x. **Four sat in commands Clawdeck offers
+by name**, so three more labs would have failed the same way.
+
+Two properties keep it honest, and both matter:
+
+- **A constructor whose signature takes `**kwargs` is skipped**, loudly. It
+  accepts anything, so a pass would be false confidence.
+- **The pinned versions in its PEP 723 header are checked against every lab's
+  `uv.lock`.** Otherwise the suite validates a version no learner runs — passing
+  while the labs are broken, which is precisely the failure it exists to
+  prevent.
+
+When bumping a library, expect this to fail and read it as a to-do list: it
+names the file, the line and the exact kwarg.
 
 ## The Clawdeck lab manifest
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ repository therefore ships **logic tests** that exercise the code paths without 
 GPU or a model download:
 
 ```bash
-./tests/run_all.sh                  # 23 suites, no GPU and no downloads
+./tests/run_all.sh                  # 24 suites, no GPU and no downloads
 uv run tests/test_ds_configs.py     # a single suite
 ```
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -42,6 +42,7 @@ TESTS=(
     tests/test_glm53_arch.py
     tests/test_qwen38_arch.py
     tests/test_clawdeck_manifest.py
+    tests/test_config_kwargs.py
 )
 
 for test in "${TESTS[@]}"; do

--- a/tests/test_config_kwargs.py
+++ b/tests/test_config_kwargs.py
@@ -1,0 +1,218 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "transformers==5.16.1",
+#   "trl==1.12.0",
+#   "peft==0.20.0",
+#   "tomli; python_version < '3.11'",
+# ]
+# ///
+"""
+Regression test: every config kwarg is accepted by the INSTALLED library.
+
+Run:
+    uv run tests/test_config_kwargs.py
+
+Why this suite exists
+---------------------
+A learner on Clawdeck ran `03_huggingface/02_trl_sft` on two rented GPUs. Both
+ranks launched, the model loaded (596M params), the dataset loaded, and then:
+
+    TypeError: TrainingArguments.__init__() got an unexpected keyword argument
+    'logging_dir'
+
+`logging_dir` was removed in transformers 5.x, which is what that lab's
+uv.lock pins. The compile check in CI could never catch it: `logging_dir=` is
+SYNTACTICALLY VALID. It fails only when the object is constructed — so library
+API drift shipped silently and was discovered by someone paying for GPU time.
+
+That is the gap this closes. For every call to a known config constructor, the
+keyword arguments are parsed with `ast` and checked against the installed
+class's signature. It needs no GPU and no model download, because the
+constructors import fine on CPU — which is the only reason this is catchable at
+all.
+
+Running it against the tree at the time it was written found **20** rejected
+kwargs across 13 files, not the one that was reported:
+
+    logging_dir           removed          4 sites
+    warmup_ratio          removed          6 sites  (only warmup_steps survives)
+    overwrite_output_dir  removed          5 sites
+    save_safetensors      removed          2 sites
+    max_prompt_length     removed          1 site   (GRPOConfig)
+
+Four of those sat in commands Clawdeck offers by name, so three more labs would
+have failed the same way the reported one did.
+
+Two properties that make this worth having rather than worse than nothing
+-------------------------------------------------------------------------
+1. **A class whose signature takes `**kwargs` is SKIPPED.** It accepts
+   everything, so a pass would prove nothing and would give false confidence.
+2. **The pinned versions here must match what the labs actually install.**
+   This file imports one transformers; the labs each have their own uv.lock. If
+   those drift apart, this suite happily validates a version no learner runs —
+   passing while the labs are broken, which is the exact failure it exists to
+   prevent. So the lock files are checked against the pins above, and a
+   mismatch fails.
+"""
+
+import ast
+import inspect
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Directories that are not this repository's source.
+SKIP_DIRS = {".venv", "node_modules", "build", ".git", "__pycache__",
+             "docusaurus-docs", ".docusaurus"}
+
+# The versions this suite validates against. They must equal what every lab's
+# uv.lock resolves, or the check is testing something no learner runs.
+PINNED = {"transformers": "5.16.1", "trl": "1.12.0", "peft": "0.20.0"}
+
+PASS = FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def load_constructors() -> dict:
+    """
+    Map constructor name -> (accepted kwargs, takes **kwargs).
+
+    Imported from the installed libraries rather than hardcoded, so the check
+    tracks the pin instead of a snapshot someone has to remember to update.
+    """
+    out = {}
+
+    def add(name, cls):
+        sig = inspect.signature(cls.__init__)
+        var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD
+                     for p in sig.parameters.values())
+        out[name] = (set(sig.parameters) - {"self"}, var_kw)
+
+    import transformers
+    for n in ("TrainingArguments", "Seq2SeqTrainingArguments"):
+        if hasattr(transformers, n):
+            add(n, getattr(transformers, n))
+    import trl
+    for n in ("SFTConfig", "DPOConfig", "GRPOConfig", "RewardConfig",
+              "OnlineDPOConfig", "CPOConfig", "KTOConfig", "ORPOConfig"):
+        if hasattr(trl, n):
+            add(n, getattr(trl, n))
+    import peft
+    for n in ("LoraConfig",):
+        if hasattr(peft, n):
+            add(n, getattr(peft, n))
+    return out
+
+
+def locked_version(lock: Path, pkg: str):
+    m = re.search(rf'\nname = "{pkg}"\nversion = "([^"]+)"', lock.read_text())
+    return m.group(1) if m else None
+
+
+def main() -> None:
+    bar = "=" * 74
+    print(bar)
+    print("  test_config_kwargs.py")
+    print(bar)
+
+    # ---- the pins must match what the labs install ------------------------
+    print("\n  -- this suite validates the version the labs actually use --")
+    import transformers, trl, peft
+    installed = {"transformers": transformers.__version__,
+                 "trl": trl.__version__, "peft": peft.__version__}
+    for pkg, want in PINNED.items():
+        check(f"{pkg} {installed[pkg]} is the pinned {want}",
+              installed[pkg] == want,
+              "the PEP 723 header above and the running interpreter disagree")
+
+    drift = []
+    for lock in sorted(REPO.glob("*/*/uv.lock")):
+        for pkg, want in PINNED.items():
+            got = locked_version(lock, pkg)
+            if got is not None and got != want:
+                drift.append(f"{lock.parent}: {pkg} {got} != {want}")
+    check(f"every lab's uv.lock agrees with these pins "
+          f"({len(list(REPO.glob('*/*/uv.lock')))} locks)",
+          not drift,
+          "; ".join(drift[:4]) + " -- this suite would validate a version no "
+          "learner runs, passing while the labs are broken")
+
+    # ---- the constructors -------------------------------------------------
+    print("\n  -- constructors under test --")
+    ctors = load_constructors()
+    check(f"loaded {len(ctors)} config constructors", len(ctors) >= 8,
+          f"got {sorted(ctors)}")
+    skipped = []
+    for name in sorted(ctors):
+        accepted, var_kw = ctors[name]
+        if var_kw:
+            # Not a failure -- but say so out loud. A class that accepts
+            # everything cannot be validated, and silently counting it as a
+            # pass is how a checker starts lying.
+            skipped.append(name)
+            print(f"  SKIP  {name}: takes **kwargs, so a pass would prove nothing")
+        else:
+            check(f"{name}: {len(accepted)} accepted kwargs, checkable",
+                  len(accepted) > 0)
+    if skipped:
+        print(f"        {len(skipped)} constructor(s) skipped: {skipped}")
+
+    # ---- every call site --------------------------------------------------
+    print("\n  -- every config constructor call in the repo --")
+    findings = []
+    scanned = 0
+    for path in sorted(REPO.rglob("*.py")):
+        rel = path.relative_to(REPO)
+        if any(p in SKIP_DIRS for p in rel.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(errors="ignore"))
+        except SyntaxError:
+            continue
+        scanned += 1
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            f = node.func
+            name = (f.id if isinstance(f, ast.Name)
+                    else f.attr if isinstance(f, ast.Attribute) else None)
+            if name not in ctors:
+                continue
+            accepted, var_kw = ctors[name]
+            if var_kw:
+                continue
+            for kw in node.keywords:
+                if kw.arg is None:
+                    continue          # **spread; cannot be checked statically
+                if kw.arg not in accepted:
+                    findings.append((rel, kw.lineno, name, kw.arg))
+
+    check(f"scanned {scanned} python files", scanned > 50)
+    check(f"no rejected kwargs ({len(findings)} found)", not findings,
+          "; ".join(f"{p}:{ln} {c}(... {k}=...)"
+                    for p, ln, c, k in findings[:6]))
+    for rel, ln, cls, kw in findings:
+        print(f"        {rel}:{ln}  {cls}(... {kw}=...) is not accepted by the "
+              f"installed library")
+
+    print("\n" + bar)
+    print(f"  {PASS} passed, {FAIL} failed")
+    print(bar)
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Your report was correct — and incomplete. Writing the checker **first** and running it against the unfixed tree, as you asked, found **20 rejected kwargs across 13 files**, not 3.

## Four labs were broken, not two

| lab | Clawdeck button | |
|---|---|---|
| `03_huggingface/02_trl_sft` | Full run | reported |
| `04_video_text/01_hf_baseline` | Train | reported |
| **`03_huggingface/08_gpt_oss_lora`** | **Train (20 steps)** | **not reported** |
| **`05_video_speech/01_longcat_omni`** | **Train (10 steps)** | **not reported** |

Your grep was for `logging_dir`; the class is wider:

| kwarg | sites | status |
|---|---|---|
| `logging_dir` | 4 | removed in transformers 5.x |
| `warmup_ratio` | 6 | removed; only `warmup_steps` survives |
| `overwrite_output_dir` | 5 | removed |
| `save_safetensors` | 2 | removed; safetensors is now default |
| `max_prompt_length` | 1 | removed from `GRPOConfig` in trl 1.x |

Each was confirmed by **constructing the object**, not by introspection alone — `warmup_ratio` vanishing is surprising enough to disprove before editing six call sites on the strength of a signature dump.

## `warmup_ratio` is not a rename

Only the absolute `warmup_steps` survives, and the old value was a *fraction* of a total step count that depends on dataset size — not statically convertible. Silently dropping it would change the LR schedule, so each site sets a small absolute `warmup_steps` with a comment saying the number is arbitrary and should be tuned. Flagging that as the one judgement call in here.

## The check

`tests/test_config_kwargs.py`, built to your design, registered in `run_all.sh` and `tests.yml` (24 suites). CPU-only, no downloads. Skips `**kwargs` classes loudly. Names file, line and kwarg.

**One property your design was missing:** the versions in its PEP 723 header are checked against **every lab's `uv.lock`**. This file imports one transformers while the labs each pin their own — if those drift apart, the suite validates a version no learner runs, *passing while the labs are broken*. That is precisely the failure it exists to prevent, so a mismatch now fails.

## Watched it fail, twice

| Break | Result |
|---|---|
| reintroduce `logging_dir` | ✅ `train_trl_deepspeed.py:196 TrainingArguments(... logging_dir=...)` |
| desync the pin from the locks | ✅ names all 26 locks that disagree |

Plus the run against the unfixed tree, which is how the other 16 sites surfaced.

Agreed the platform behaved correctly throughout — this was entirely ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa