### PR TITLE
docs: Record the iOS icon contract in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,4 +574,18 @@ There are **two** CI workflows:
   palette, the absence of inline overrides, label quoting, and that the config
   still sets what CONTRIBUTING.md publishes — all 40 diagram pages conform.
 
+- **The site's own background is `#000000`**, not the dark blue of the Mermaid
+  palette above — `custom.css` sets `--ifm-background-color: #000000` and dark
+  mode is the only mode. Those are two different colour systems and it is easy
+  to assume one from the other.
+- **`headTags` in `docusaurus.config.js` carries the iOS home-screen icon**, and
+  it is load-bearing: iOS Safari ignores `<link rel="icon">` for "Add to Home
+  Screen" and shows a **letter tile** without an `apple-touch-icon`. The site
+  did exactly that — a bare "D" — until the tags were added. The icons under
+  `static/img/` (180 for iOS, 192 and 512 for the manifest) are **pre-flattened
+  onto black on purpose**: iOS does not honour transparency in home-screen icons
+  and composites it to black regardless, so doing it deliberately makes the
+  result the site's own background instead of the renderer's choice. iOS also
+  masks the corners, hence the padding.
+
 - **Verifying a deployed page needs a content check, not a status code.** A 200 only proves *a* page is there, not the new one — and a literal `grep` for text inside a KaTeX block will fail because it renders into split HTML spans. Match on plain prose instead.


### PR DESCRIPTION
Audit of CLAUDE.md against the tree, plus one gap closed.

## Audit result: it was already accurate

All 19 verifiable claims hold — 25 suites, ~34 `require_gpu()` files, 10 CPU-runnable modules, 40 diagram pages, and every test and script it names exists. The Clawdeck-manifest, config-kwarg and torch-index sections added earlier this session are all current. Nothing was stale.

## The one gap

The docs-site section said nothing about `headTags`, and the fact behind it isn't guessable: **iOS Safari ignores `<link rel="icon">` for "Add to Home Screen" and renders a letter tile** without an `apple-touch-icon`. The site showed a bare "D" until the tags were added. Someone regenerating `docusaurus.config.js` would drop them and never see a build error — nothing in the Docusaurus build warns.

Also records two things that would otherwise be re-derived the hard way:

- **Why the icons are pre-flattened onto black** rather than reusing the transparent source: iOS composites transparency to black regardless, so doing it deliberately makes the result the site's own background instead of the renderer's choice.
- **The site background is `#000000`, while the Mermaid palette is dark blue.** Two separate colour systems that are easy to conflate — and conflating them is exactly what would produce an off-brand icon.

## Verification

Every added claim checked against the tree, not recalled: `custom.css` sets `--ifm-background-color: #000000`, the config contains `headTags` and `apple-touch-icon`, all three icon files and the manifest exist, and the PNGs really are `mode=RGB` (opaque).

25 suites pass; `test_docs_style.py` 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa