### PR TITLE
fix: Give 02_convnet learnable data, and stop reporting smoke tests as failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: torch-linked packages share torch's index
         run: uv run tests/test_torch_index_pins.py
 
+      - name: Synthetic data contains a learnable signal
+        run: uv run tests/test_synthetic_data_is_learnable.py
+
       - name: Every training script compiles
         run: |
           uv run --no-project python -m compileall -q \

--- a/01_basics/02_convnet/README.md
+++ b/01_basics/02_convnet/README.md
@@ -487,12 +487,15 @@ if WANDB_AVAILABLE and wandb_api_key:
    - Accuracy Gain: 4.50%
 
 🏆 Model Quality Assessment:
-   ❌ Poor. Consider training longer or adjusting hyperparameters
+   ✅ Good! Model achieved ≥70% accuracy
 
-💡 Note:
-   - This is trained on random synthetic data (not real MNIST)
-   - High accuracy on random data indicates the model is learning patterns
-   - For real MNIST, accuracy should approach 98-99%
+💡 What this number means:
+   - Synthetic data: each class is a fixed 28x28 prototype plus noise,
+     so the label IS recoverable from the image. Chance is 10%.
+   - A short run (1 epoch) may land well below the ceiling. That is the
+     run being short, not the model being wrong -- use --epochs 10 for a
+     result worth reading.
+   - Raise --noise to make the task harder; at 0 it is nearly trivial.
 
 ================================================================================
 🎉 Enhanced CNN Training Script Finished Successfully!
@@ -530,7 +533,14 @@ The script automatically evaluates model quality:
 | **Fair** | ≥50% | Parameters are reasonably close |
 | **Poor** | <50% | Consider training longer or adjusting hyperparameters |
 
-**Note**: With synthetic random data, expect "Poor" quality. With real MNIST data, expect 95-99% accuracy.
+**Note**: the synthetic data is **learnable** — each class is a fixed 28×28
+prototype plus noise — so accuracy is a real signal. Chance is 10%; a plain MLP
+reaches ~82% after one epoch and ~89% after eight at the default `--noise 8.0`.
+
+This was not always true. The generator used to draw labels *independently* of
+the images, which put the ceiling at chance and made every run report "Poor" —
+advice that could not be acted on, because no amount of training can beat
+10% when there is no signal to find.
 
 ## Model Usage After Training
 
@@ -629,9 +639,10 @@ DS_BUILD_OPS=1 uv add "deepspeed>=0.12.0"
 ```
 
 #### Loss Not Decreasing
-This is expected with random synthetic data. To see actual learning:
-- Use real MNIST dataset (see "Using with Real MNIST Data" section)
-- Check data loader is shuffling properly
+The data is learnable, so a flat loss is a real symptom rather than expected:
+- Lower `--noise` (default 8.0); above ~16 the classes genuinely overlap and
+  accuracy falls back toward the 10% chance floor
+- Check the data loader is shuffling properly
 - Verify learning rate is appropriate
 - Monitor gradient norms (should be neither too large nor too small)
 

--- a/01_basics/02_convnet/train_ds.py
+++ b/01_basics/02_convnet/train_ds.py
@@ -136,23 +136,67 @@ class CNNModelEnhanced(nn.Module):
         return x
 
 
-def get_data_loader(batch_size: int, num_samples: int = 10000) -> DataLoader:
+def get_data_loader(batch_size: int, num_samples: int = 10000,
+                    noise: float = 8.0, seed: int = 42,
+                    task_seed: int = 12345) -> DataLoader:
     """
-    Generates a random dataset that simulates MNIST:
-    - 28x28 grayscale images (1 channel)
-    - Integer labels 0-9
+    Synthetic 28x28 images whose labels are LEARNABLE from the pixels.
+
+    Each class owns a fixed random 28x28 prototype, and a sample is that
+    prototype plus Gaussian noise. So the label is genuinely a function of the
+    image, a CNN can recover it in about one epoch, and accuracy is a real
+    signal rather than decoration.
+
+    This used to be:
+
+        x_data = torch.randn(num_samples, 1, 28, 28)   # noise
+        y_data = torch.randint(0, 10, (num_samples,))  # labels INDEPENDENT of x
+
+    which has zero mutual information between inputs and labels. Chance (~10%)
+    was not a poor result there, it was the information-theoretic CEILING: no
+    architecture, learning rate or epoch count could beat it. The script none
+    the less printed "Poor. Consider training longer or adjusting
+    hyperparameters", which sent readers off to tune an unreachable target.
+    Two runs on a 3090 returned 10.29% and 9.49%, identical to four significant
+    figures from first epoch to last -- the signature of a classifier collapsing
+    to a single class, which is the correct degenerate answer when there is no
+    signal to find.
+
+    Every other lab in 01_basics already generates learnable synthetic data --
+    01_neuralnet uses y = 2x + 1, 04_rnn uses a sum of sines. This one was the
+    exception, and now is not.
+
+    The prototypes come from `task_seed`, NOT `seed`, so the train and eval
+    splits describe the SAME task. Drawing a fresh set per call would make them
+    unrelated problems, and training would then make accuracy worse -- a bug
+    this course has shipped before, in a ranking generator.
 
     Args:
         batch_size: Number of samples per batch
         num_samples: Total number of training samples
+        noise: Gaussian noise added to each prototype. The default of 8.0 is
+            CALIBRATED, not guessed: a plain MLP reaches ~82% after one epoch
+            and ~89% after eight, so a single-epoch smoke test visibly clears
+            the 10% chance floor while longer runs still improve. Lower values
+            are trivial -- at 5.0 the task is solved to 99% in one epoch,
+            because 784 dimensions of signal average out a lot of per-pixel
+            noise. Above ~16 it falls back toward chance.
+        seed: Draws the noise and the label sequence
+        task_seed: Draws the class prototypes -- the task itself
 
     Returns:
-        DataLoader with synthetic MNIST-like data
+        DataLoader over learnable synthetic data
     """
-    # Set seed for reproducibility
-    torch.manual_seed(42)
-    x_data = torch.randn(num_samples, 1, 28, 28)
-    y_data = torch.randint(0, 10, (num_samples,))
+    # The task: one fixed prototype image per class.
+    task_gen = torch.Generator().manual_seed(task_seed)
+    prototypes = torch.randn(10, 1, 28, 28, generator=task_gen)
+
+    # The sample: a prototype, plus noise.
+    gen = torch.Generator().manual_seed(seed)
+    y_data = torch.randint(0, 10, (num_samples,), generator=gen)
+    x_data = prototypes[y_data] + noise * torch.randn(
+        num_samples, 1, 28, 28, generator=gen)
+
     dataset = TensorDataset(x_data, y_data)
     return DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
@@ -213,6 +257,10 @@ def parse_args() -> "argparse.Namespace":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--epochs", type=int, default=50,
                         help="Training epochs (default: 50).")
+    parser.add_argument("--noise", type=float, default=8.0,
+                        help="Gaussian noise added to each class prototype. "
+                             "At 0 the task is nearly trivial; raise it to "
+                             "make the classes overlap.")
     parser.add_argument("--max-steps", type=int, default=-1,
                         help="Stop after this many optimizer steps. -1 means "
                              "no cap. Used by the dry-run path; a handful of "
@@ -298,7 +346,8 @@ def main() -> None:
     print(f"✅ DeepSpeed initialized successfully")
 
     batch_size = model_engine.train_micro_batch_size_per_gpu()
-    data_loader = get_data_loader(batch_size=batch_size, num_samples=10000)
+    data_loader = get_data_loader(batch_size=batch_size, num_samples=10000,
+                                  noise=args.noise)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     print(f"\n💻 Training Configuration:")
@@ -514,14 +563,34 @@ def main() -> None:
         print(f"   ✅ Good! Model achieved ≥70% accuracy")
     elif quality_score == "fair":
         print(f"   ⚠️  Fair. Model achieved ≥50% accuracy")
+    elif args.epochs <= 2 or args.max_steps > 0:
+        # Do not tell a reader their smoke test failed. It did not. This is the
+        # path Clawdeck's default command takes (--epochs 1 / --max-steps 20),
+        # and printing "Poor. Consider training longer or adjusting
+        # hyperparameters" under a "Finished Successfully" banner is how a
+        # beginner concludes they broke something.
+        short = (f"--max-steps {args.max_steps}" if args.max_steps > 0
+                 else f"{args.epochs} epoch(s)")
+        print(f"   ⏱️  Below 50%, but this run was capped at {short} -- too short")
+        print(f"      to be meaningful. This is a PIPELINE smoke test: success means")
+        print(f"      DeepSpeed launched, both ranks ran, and the loss moved.")
+        print(f"      Use --epochs 10 for a number worth reading.")
     else:
-        print(f"   ❌ Poor. Consider training longer or adjusting hyperparameters")
+        print(f"   ❌ Poor after {args.epochs} epochs. Check the learning rate, or")
+        print(f"      lower --noise: at high noise the classes genuinely overlap.")
 
-    # Note about synthetic data
-    print(f"\n💡 Note:")
-    print(f"   - This is trained on random synthetic data (not real MNIST)")
-    print(f"   - High accuracy on random data indicates the model is learning patterns")
-    print(f"   - For real MNIST, accuracy should approach 98-99%")
+    # What the number means. All three lines here used to be wrong: they
+    # described random labels ("High accuracy on random data indicates the
+    # model is learning patterns" -- backwards; on random labels that is
+    # memorisation, and unreachable on a held-out split anyway) and pointed at
+    # MNIST, which this lab never touches.
+    print(f"\n💡 What this number means:")
+    print(f"   - Synthetic data: each class is a fixed 28x28 prototype plus noise,")
+    print(f"     so the label IS recoverable from the image. Chance is 10%.")
+    print(f"   - A short run (1 epoch) may land well below the ceiling. That is the")
+    print(f"     run being short, not the model being wrong -- use --epochs 10 for a")
+    print(f"     result worth reading.")
+    print(f"   - Raise --noise to make the task harder; at 0 it is nearly trivial.")
 
     # Log final summary to W&B
     if use_wandb:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ passed on all of them. Established patterns to copy:
   (catastrophic cancellation), so exact equality is the wrong test.
 
 ```bash
-./tests/run_all.sh              # all 25 suites, no GPU, no downloads
+./tests/run_all.sh              # all 26 suites, no GPU, no downloads
 uv run tests/test_ds_configs.py # one suite
 ```
 
@@ -358,6 +358,37 @@ Two signatures worth recognising:
   the box advertising peer-to-peer it cannot perform. `nvidia-smi topo -m`
   showing `SYS` between cards is the tell; `NCCL_P2P_DISABLE=1` is the fix, at
   a real throughput cost. `tests/gpu/diagnose_nccl.sh` decides it in a minute.
+
+### Synthetic data must carry a signal, and the summary must not lie
+
+`01_basics/02_convnet` drew `x = randn(...)` and `y = randint(...)` — labels
+independent of the images, so **zero mutual information**. On 10 classes ~10%
+was not a poor result, it was the information-theoretic **ceiling**. The script
+none the less exited 0, printed "Finished Successfully", and advised *"Poor.
+Consider training longer or adjusting hyperparameters"* — sending a reader to
+tune a target that cannot be reached. Two 3090 runs returned 10.29% and 9.49%,
+unchanged from first epoch to last: a classifier collapsing to one class, the
+correct degenerate answer when there is nothing to learn.
+
+Every other lab in `01_basics` already used learnable synthetic data
+(`y = 2x + 1`, a sum of sines); this one was the exception. It now builds a
+fixed prototype per class plus noise, and the noise default is **calibrated,
+not guessed** — at 5.0 a plain MLP hits 99% in one epoch, because 784
+dimensions of signal average out per-pixel noise; 8.0 gives ~82% at one epoch
+rising to ~89%, so a short run visibly clears chance and longer runs still
+improve.
+
+Two rules follow:
+
+- **A short run must not be reported as a failure.** Clawdeck runs these with
+  `--epochs 1`; printing "Poor" under a "Finished Successfully" banner is how a
+  beginner concludes they broke something. Say the run was capped and what a
+  real one looks like.
+- **`tests/test_synthetic_data_is_learnable.py` asserts it**, on a HELD-OUT
+  split — memorising random labels on the training set is possible and proves
+  the opposite of learning. It carries the old generator as a counterexample
+  and asserts it FAILS, because a learnability check that never sees
+  unlearnable data would pass while returning True unconditionally.
 
 ### A custom torch index pins its companions too, or nothing works
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ repository therefore ships **logic tests** that exercise the code paths without 
 GPU or a model download:
 
 ```bash
-./tests/run_all.sh                  # 25 suites, no GPU and no downloads
+./tests/run_all.sh                  # 26 suites, no GPU and no downloads
 uv run tests/test_ds_configs.py     # a single suite
 ```
 

--- a/clawdeck.yaml
+++ b/clawdeck.yaml
@@ -76,7 +76,7 @@ labs:
 
   - id: 01_basics/02_convnet
     title: "ConvNet on MNIST"
-    summary: "A CNN with ZeRO, on synthetic MNIST-shaped data."
+    summary: "A CNN with ZeRO on learnable synthetic 28x28 images."
     est_minutes: 4
     gpu: { min_vram_gb: 6, count: 1 }
     run:

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -44,6 +44,7 @@ TESTS=(
     tests/test_clawdeck_manifest.py
     tests/test_config_kwargs.py
     tests/test_torch_index_pins.py
+    tests/test_synthetic_data_is_learnable.py
 )
 
 for test in "${TESTS[@]}"; do

--- a/tests/test_synthetic_data_is_learnable.py
+++ b/tests/test_synthetic_data_is_learnable.py
@@ -1,0 +1,194 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["torch", "numpy"]
+# ///
+"""
+Regression test: synthetic training data actually contains a learnable signal.
+
+Run:
+    uv run tests/test_synthetic_data_is_learnable.py
+
+Why this suite exists
+---------------------
+`01_basics/02_convnet` generated its dataset like this:
+
+    x_data = torch.randn(num_samples, 1, 28, 28)     # noise images
+    y_data = torch.randint(0, 10, (num_samples,))    # labels INDEPENDENT of x
+
+There is zero mutual information between inputs and labels, so ~10% is not a
+poor result on 10 classes — it is the information-theoretic **ceiling**. No
+architecture, learning rate or epoch count can beat it.
+
+The script exited 0, printed "Finished Successfully", and then advised:
+
+    "Poor. Consider training longer or adjusting hyperparameters"
+
+which sends a learner to tune an unreachable target. Two runs on a 3090
+returned 10.29% and 9.49%, identical from first epoch to last — the signature
+of a classifier collapsing to one class, the correct degenerate answer when
+there is no signal.
+
+Nothing in CI could catch it. The script runs, exits 0, and reports a number.
+`compileall` sees valid Python; the manifest checker sees a valid lab.
+
+What this asserts
+-----------------
+For each generator, that a small model trained on it beats chance on a HELD-OUT
+split drawn with a different seed. That is the property the fix is about:
+
+  * held-out, not training accuracy — memorising random labels is possible on
+    the training set and proves nothing (Zhang et al., "Understanding deep
+    learning requires rethinking generalization"). It is exactly the thing the
+    old script mistook for evidence of learning.
+  * a different seed for the eval split, so train and eval describe the same
+    task. A generator that draws a fresh hidden task per call makes them
+    unrelated problems, and training then makes the metric worse — a bug this
+    course shipped once already, in a ranking generator.
+
+And the counterexample, without which the check proves nothing: the ORIGINAL
+random-label generator is reconstructed here and asserted to FAIL. A test that
+only ever sees good data would pass if it always returned True.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, TensorDataset
+
+REPO = Path(__file__).resolve().parent.parent
+
+PASS = FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def load_generator(rel_path: str, func: str):
+    """
+    Pull one generator out of a training script without importing it.
+
+    The scripts import deepspeed at module scope in places, and deepspeed on a
+    CPU box without a launcher tries MPI discovery and dies. Parsing out the
+    single function keeps this suite CPU-only and dependency-light.
+    """
+    src = (REPO / rel_path).read_text()
+    tree = ast.parse(src)
+    fn = next((n for n in tree.body
+               if isinstance(n, ast.FunctionDef) and n.name == func), None)
+    if fn is None:
+        return None
+    ns = {"torch": torch, "DataLoader": DataLoader,
+          "TensorDataset": TensorDataset}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), rel_path, "exec"), ns)
+    return ns[func]
+
+
+def beats_chance(loader_fn, n_classes: int, epochs: int = 2) -> float:
+    """Held-out accuracy of a small MLP, as a percentage."""
+    # Pass only the kwargs this generator actually accepts. A generator with
+    # no `seed` parameter must still be MEASURED -- the first version of this
+    # helper passed seed= unconditionally and died with
+    #     TypeError: get_data_loader() got an unexpected keyword argument 'seed'
+    # against the very generator it was written to catch. CI went red, but for
+    # the wrong reason and with a message that named a signature mismatch
+    # instead of the finding.
+    import inspect
+    accepts = set(inspect.signature(loader_fn).parameters)
+
+    def build(n, seed):
+        kw = {"batch_size": 256, "num_samples": n}
+        if "seed" in accepts:
+            kw["seed"] = seed
+        else:
+            torch.manual_seed(seed)   # the only handle such a generator offers
+        return loader_fn(**kw)
+
+    torch.manual_seed(0)
+    train = build(6000, 1)
+    test = build(1500, 2)
+
+    x0, _ = next(iter(train))
+    model = nn.Sequential(nn.Flatten(),
+                          nn.Linear(x0[0].numel(), 64), nn.ReLU(),
+                          nn.Linear(64, n_classes))
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for _ in range(epochs):
+        for x, y in train:
+            opt.zero_grad()
+            nn.functional.cross_entropy(model(x), y).backward()
+            opt.step()
+    correct = total = 0
+    with torch.no_grad():
+        for x, y in test:
+            correct += (model(x).argmax(1) == y).sum().item()
+            total += y.numel()
+    return 100.0 * correct / total
+
+
+def main() -> None:
+    bar = "=" * 74
+    print(bar)
+    print("  test_synthetic_data_is_learnable.py")
+    print(bar)
+
+    print("\n  -- 01_basics/02_convnet --")
+    gen = load_generator("01_basics/02_convnet/train_ds.py", "get_data_loader")
+    check("get_data_loader was found in the shipped source", gen is not None)
+    if gen is None:
+        print(f"\n  {PASS} passed, {FAIL} failed")
+        sys.exit(1)
+
+    acc = beats_chance(gen, n_classes=10)
+    chance = 10.0
+    check(f"held-out accuracy {acc:.1f}% clears the {chance:.0f}% chance floor",
+          acc > chance * 2.5,
+          f"got {acc:.1f}%. If the labels are independent of the images there "
+          "is no signal to find, and chance is the CEILING rather than a poor "
+          "result -- the script would then advise a reader to train longer "
+          "toward a target that cannot be reached.")
+
+    # Learnable but not trivial: if one epoch already saturates, the accuracy
+    # number stops discriminating and the run length teaches nothing.
+    quick = beats_chance(gen, n_classes=10, epochs=1)
+    check(f"one epoch already shows learning ({quick:.1f}%), so a smoke test "
+          "reads as success", quick > chance * 2.5,
+          "Clawdeck runs this lab with --epochs 1; if that lands at chance a "
+          "beginner concludes they broke something")
+
+    # ---- the counterexample -------------------------------------------------
+    # Without this the check proves nothing: a function that always returned
+    # True would pass everything above.
+    print("\n  -- the counterexample: the generator this replaced --")
+
+    def random_labels(batch_size: int, num_samples: int = 10000, seed: int = 42,
+                      **kw):
+        g = torch.Generator().manual_seed(seed)
+        x = torch.randn(num_samples, 1, 28, 28, generator=g)
+        y = torch.randint(0, 10, (num_samples,), generator=g)
+        return DataLoader(TensorDataset(x, y), batch_size=batch_size,
+                          shuffle=True)
+
+    bad = beats_chance(random_labels, n_classes=10)
+    check(f"random labels stay at chance ({bad:.1f}%) and are REJECTED",
+          bad <= chance * 2.5,
+          f"got {bad:.1f}% on data with zero mutual information -- if this "
+          "passes, the check is not measuring learnability at all")
+
+    print("\n" + bar)
+    print(f"  {PASS} passed, {FAIL} failed")
+    print(bar)
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Both problems confirmed exactly as reported, and fixed.

## Problem 1 — a third option that fits better than either you offered

You suggested real MNIST, or keeping synthetic and admitting 10% is the expected result. There's a third: **every other lab in `01_basics` already generates learnable synthetic data** — `01_neuralnet` uses `y = 2x + 1`, `04_rnn` a sum of sines. `02_convnet` was the exception.

It now draws a fixed prototype per class plus noise, so the label is genuinely recoverable from the image. No download, fast smoke-test character intact, and consistent with the section's own design.

**The noise default is calibrated, not guessed.** Measured on a plain MLP:

| noise | 1 epoch | 8 epochs |
|---|---|---|
| 5.0 | 99.3% | 99.8% |
| **8.0** | **81.9%** | **89.0%** |
| 16.0 | 29.5% | 39.2% |

Low noise is *trivial* — 784 dimensions of signal average out a lot of per-pixel noise — which is a different way for the metric to be uninformative. 8.0 means one epoch visibly clears the 10% floor while longer runs still improve.

All three false statements are gone, plus the same text in the README.

## Problem 2 — fixed

The assessment now detects a capped run (`--epochs 1` / `--max-steps`), says so, and states what success means for a smoke test, instead of "Poor" under "Finished Successfully".

## Two bugs of my own, caught by running it

- The new summary referenced an undefined `epochs_run` and advised a `--noise` flag that didn't exist. Both would have fired at the very end of a completed run. `--noise` is now real and wired through.
- **The new test passed `seed=` unconditionally and died with `TypeError` against the very generator it was written to catch.** CI went red, but naming a signature mismatch rather than the finding. It now adapts to the signature and correctly reports 11.1% at chance.

## The guard

`tests/test_synthetic_data_is_learnable.py` asserts learnability on a **held-out** split — memorising random labels on the training set is possible and proves the opposite of learning, which is exactly what the old script mistook for evidence.

It carries the original generator as a **counterexample and asserts it fails**, because a learnability check that never sees unlearnable data would pass while returning `True` unconditionally.

Verified both ways:

| | result |
|---|---|
| shipped generator | ❌ 11.1% held-out, 10.6% at 1 epoch — both flagged |
| fixed generator | ✅ 85.1% held-out, 74.9% at 1 epoch |

26 suites, all pass.

## Not addressed here

The other three labs (`01_neuralnet`, `03_convnet_cifar10`, `04_rnn`) are learnable — their flat metrics are the short default runs, which Problem 2's banner change addresses at the source. Raising their default epochs is a separate call about smoke-test cost, and I'd rather you decide it than have me quietly make runs longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa