### PR TITLE
fix: Restore the pre-rename book URLs, and finish the package names

### DIFF
--- a/03_llms/01_llm_finetuning/pyproject.toml
+++ b/03_llms/01_llm_finetuning/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-05-huggingface"
+name = "deepspeed-course-03-llms-01-llm-finetuning"
 version = "0.1.0"
 description = "HuggingFace LLM fine-tuning with DeepSpeed ZeRO"
 readme = "README.md"

--- a/03_llms/01_llm_finetuning/uv.lock
+++ b/03_llms/01_llm_finetuning/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-05-huggingface"
+name = "deepspeed-course-03-llms-01-llm-finetuning"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/02_trl_sft/pyproject.toml
+++ b/03_llms/02_trl_sft/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-05-huggingface-trl"
+name = "deepspeed-course-03-llms-02-trl-sft"
 version = "0.1.0"
 description = "TRL supervised fine-tuning for function calling"
 readme = "README.md"

--- a/03_llms/02_trl_sft/uv.lock
+++ b/03_llms/02_trl_sft/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-05-huggingface-trl"
+name = "deepspeed-course-03-llms-02-trl-sft"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/03_ocr/pyproject.toml
+++ b/03_llms/03_ocr/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-05-huggingface-ocr"
+name = "deepspeed-course-03-llms-03-ocr"
 version = "0.1.0"
 description = "Vision-language OCR fine-tuning"
 readme = "README.md"

--- a/03_llms/03_ocr/uv.lock
+++ b/03_llms/03_ocr/uv.lock
@@ -740,7 +740,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-05-huggingface-ocr"
+name = "deepspeed-course-03-llms-03-ocr"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/04_reward_model/pyproject.toml
+++ b/03_llms/04_reward_model/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-05-huggingface-reward-model"
+name = "deepspeed-course-03-llms-04-reward-model"
 version = "0.1.0"
 description = "Bradley-Terry reward modelling on preference pairs"
 readme = "README.md"

--- a/03_llms/04_reward_model/uv.lock
+++ b/03_llms/04_reward_model/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-05-huggingface-reward-model"
+name = "deepspeed-course-03-llms-04-reward-model"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/05_dpo/pyproject.toml
+++ b/03_llms/05_dpo/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-05-huggingface-dpo"
+name = "deepspeed-course-03-llms-05-dpo"
 version = "0.1.0"
 description = "DPO and its descendants: six preference objectives"
 readme = "README.md"

--- a/03_llms/05_dpo/uv.lock
+++ b/03_llms/05_dpo/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-05-huggingface-dpo"
+name = "deepspeed-course-03-llms-05-dpo"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/06_grpo/pyproject.toml
+++ b/03_llms/06_grpo/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-06-huggingface-grpo"
+name = "deepspeed-course-03-llms-06-grpo"
 version = "0.1.0"
 description = "GRPO on GSM8K: RL without a critic"
 readme = "README.md"

--- a/03_llms/06_grpo/uv.lock
+++ b/03_llms/06_grpo/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-06-huggingface-grpo"
+name = "deepspeed-course-03-llms-06-grpo"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/07_online_dpo/pyproject.toml
+++ b/03_llms/07_online_dpo/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-06-huggingface-online-dpo"
+name = "deepspeed-course-03-llms-07-online-dpo"
 version = "0.1.0"
 description = "Online preference optimization: Online DPO, Nash-MD, XPO"
 readme = "README.md"

--- a/03_llms/07_online_dpo/uv.lock
+++ b/03_llms/07_online_dpo/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-06-huggingface-online-dpo"
+name = "deepspeed-course-03-llms-07-online-dpo"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/08_gpt_oss_lora/pyproject.toml
+++ b/03_llms/08_gpt_oss_lora/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-07-huggingface-openai-gpt-oss-finetune-sft"
+name = "deepspeed-course-03-llms-08-gpt-oss-lora"
 version = "0.1.0"
 description = "LoRA SFT of a 20B GPT-OSS model"
 readme = "README.md"

--- a/03_llms/08_gpt_oss_lora/uv.lock
+++ b/03_llms/08_gpt_oss_lora/uv.lock
@@ -558,7 +558,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-07-huggingface-openai-gpt-oss-finetune-sft"
+name = "deepspeed-course-03-llms-08-gpt-oss-lora"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/09_multi_agency/pyproject.toml
+++ b/03_llms/09_multi_agency/pyproject.toml
@@ -14,7 +14,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-07-huggingface-trl-multi-agency"
+name = "deepspeed-course-03-llms-09-multi-agency"
 version = "0.1.0"
 description = "Multi-agent GRPO with TRL"
 readme = "README.md"

--- a/03_llms/09_multi_agency/uv.lock
+++ b/03_llms/09_multi_agency/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 ]
 
 [[package]]
-name = "deepspeed-course-07-huggingface-trl-multi-agency"
+name = "deepspeed-course-03-llms-09-multi-agency"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/03_llms/10_deepseek_from_scratch/pyproject.toml
+++ b/03_llms/10_deepseek_from_scratch/pyproject.toml
@@ -18,7 +18,7 @@
 # =============================================================================
 
 [project]
-name = "deepspeed-course-03-huggingface-10-deepseek-from-scratch"
+name = "deepspeed-course-03-llms-10-deepseek-from-scratch"
 version = "0.1.0"
 description = "DeepSeek MLA from Scratch"
 readme = "README.md"

--- a/03_llms/10_deepseek_from_scratch/uv.lock
+++ b/03_llms/10_deepseek_from_scratch/uv.lock
@@ -303,7 +303,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e8/bc/96f6154dcb825b0004961b877480a1896fe2816c7b205171d86eae2e0b56/deepspeed-0.19.6.tar.gz", hash = "sha256:31593acffbe4794c74446094122b1bc29d8c73a137e37aff899ca4a6480df2d8", size = 1923541, upload-time = "2026-08-27T19:09:27.166Z" }
 
 [[package]]
-name = "deepspeed-course-03-huggingface-10-deepseek-from-scratch"
+name = "deepspeed-course-03-llms-10-deepseek-from-scratch"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/docusaurus-docs/docusaurus.config.js
+++ b/docusaurus-docs/docusaurus.config.js
@@ -9,6 +9,37 @@ const config = {
   tagline: 'Master distributed deep learning with DeepSpeed',
   favicon: 'img/favicon.png',
 
+
+  // The section was renamed 03_huggingface -> 03_llms, which moved these 15
+  // pages. Without redirects every previously-shared link 404s: GitHub does not
+  // redirect renamed in-repo paths either, so the book is the only place this
+  // is recoverable. Old URLs exist in commit messages, in the Clawdeck team's
+  // notes, and anywhere a reader bookmarked one.
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          { from: '/docs/tutorials/huggingface/beyond-grpo', to: '/docs/tutorials/llms/beyond-grpo' },
+          { from: '/docs/tutorials/huggingface/deepseek-mla', to: '/docs/tutorials/llms/deepseek-mla' },
+          { from: '/docs/tutorials/huggingface/glm53-moe-finetuning', to: '/docs/tutorials/llms/glm53-moe-finetuning' },
+          { from: '/docs/tutorials/huggingface/gpt-oss-finetuning', to: '/docs/tutorials/llms/gpt-oss-finetuning' },
+          { from: '/docs/tutorials/huggingface/grpo-training', to: '/docs/tutorials/llms/grpo-training' },
+          { from: '/docs/tutorials/huggingface/grpo-worked-example', to: '/docs/tutorials/llms/grpo-worked-example' },
+          { from: '/docs/tutorials/huggingface/llm-finetuning', to: '/docs/tutorials/llms/llm-finetuning' },
+          { from: '/docs/tutorials/huggingface/multi-agent', to: '/docs/tutorials/llms/multi-agent' },
+          { from: '/docs/tutorials/huggingface/ocr-vision-language', to: '/docs/tutorials/llms/ocr-vision-language' },
+          { from: '/docs/tutorials/huggingface/online-preference-methods', to: '/docs/tutorials/llms/online-preference-methods' },
+          { from: '/docs/tutorials/huggingface/overview', to: '/docs/tutorials/llms/overview' },
+          { from: '/docs/tutorials/huggingface/preference-optimization', to: '/docs/tutorials/llms/preference-optimization' },
+          { from: '/docs/tutorials/huggingface/qwen38-hybrid-attention', to: '/docs/tutorials/llms/qwen38-hybrid-attention' },
+          { from: '/docs/tutorials/huggingface/rlhf-reward-modeling', to: '/docs/tutorials/llms/rlhf-reward-modeling' },
+          { from: '/docs/tutorials/huggingface/trl-function-calling', to: '/docs/tutorials/llms/trl-function-calling' }
+        ],
+      },
+    ],
+  ],
+
   // iOS ignores <link rel="icon"> for "Add to Home Screen". Without an
   // apple-touch-icon it renders a letter tile instead of the logo -- which is
   // why the site showed a bare "D". These tags are what fix that, and they must

--- a/docusaurus-docs/package.json
+++ b/docusaurus-docs/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.6.3",
+    "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/preset-classic": "^3.6.3",
     "@docusaurus/theme-mermaid": "^3.6.3",
     "@easyops-cn/docusaurus-search-local": "^0.44.5",


### PR DESCRIPTION
Two loose ends from the rename, both actionable here. The other three are handed over instead.

## 1. Redirects — restores what the rename broke

Renaming the docs folder moved 15 pages, so every previously-shared link 404'd — including three given to the Clawdeck session hours earlier, plus anything readers bookmarked. **GitHub doesn't redirect renamed in-repo paths either**, so the book is the only place any of this is recoverable.

`@docusaurus/plugin-client-redirects` now maps all 15 old paths. Verified in the build — each old URL emits a stub with both a meta refresh and a canonical link:

```html
http-equiv="refresh" content="0; url=/deepspeed-course/docs/tutorials/llms/deepseek-mla"
canonical" href="/deepspeed-course/docs/tutorials/llms/deepseek-mla"
```

So search engines follow the move rather than seeing duplicates.

This adds an npm dependency, which was deliberately out of scope for a *rename* — and is in scope for fixing what the rename broke.

## 2. Package names — the objection didn't survive testing

The ten `pyproject.toml` `name =` fields still read `deepspeed-course-05-huggingface…`, `06-`, `07-` — stale from an **earlier** restructure, so they hadn't tracked the folder for some time. I left them during the rename, arguing that relocking ten labs was churn for a string nothing reads.

**That was worth testing rather than asserting.** Renaming one and relocking produced a four-line diff touching only the root name, with no package version moved:

```
38c38
< name = "deepspeed-course-05-huggingface-trl"
> name = "deepspeed-course-03-llms-02-trl-sft"
```

Objection removed, so all ten are done: **10 locks, 10 insertions, 10 deletions, zero non-name lines changed.** `uv sync --frozen` spot-checked on two labs.

## Not fixable here — for the handover

| | |
|---|---|
| Old **GitHub** paths 404 | No redirect mechanism exists for renamed in-repo directories. Permanent. |
| In-flight pods | A box booted pre-rename has `03_huggingface/` on disk. Self-heals on reboot. |
| The other team's notes | Reference the old paths; needs a message, not a commit. |

## Verification

27 suites · 33/33 docs style · Docusaurus build clean · 15/15 redirect stubs generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa