### PR TITLE
revert: Drop the huggingface redirects — /llms/ is the only URL

### DIFF
--- a/docusaurus-docs/docusaurus.config.js
+++ b/docusaurus-docs/docusaurus.config.js
@@ -10,36 +10,6 @@ const config = {
   favicon: 'img/favicon.png',
 
 
-  // The section was renamed 03_huggingface -> 03_llms, which moved these 15
-  // pages. Without redirects every previously-shared link 404s: GitHub does not
-  // redirect renamed in-repo paths either, so the book is the only place this
-  // is recoverable. Old URLs exist in commit messages, in the Clawdeck team's
-  // notes, and anywhere a reader bookmarked one.
-  plugins: [
-    [
-      '@docusaurus/plugin-client-redirects',
-      {
-        redirects: [
-          { from: '/docs/tutorials/huggingface/beyond-grpo', to: '/docs/tutorials/llms/beyond-grpo' },
-          { from: '/docs/tutorials/huggingface/deepseek-mla', to: '/docs/tutorials/llms/deepseek-mla' },
-          { from: '/docs/tutorials/huggingface/glm53-moe-finetuning', to: '/docs/tutorials/llms/glm53-moe-finetuning' },
-          { from: '/docs/tutorials/huggingface/gpt-oss-finetuning', to: '/docs/tutorials/llms/gpt-oss-finetuning' },
-          { from: '/docs/tutorials/huggingface/grpo-training', to: '/docs/tutorials/llms/grpo-training' },
-          { from: '/docs/tutorials/huggingface/grpo-worked-example', to: '/docs/tutorials/llms/grpo-worked-example' },
-          { from: '/docs/tutorials/huggingface/llm-finetuning', to: '/docs/tutorials/llms/llm-finetuning' },
-          { from: '/docs/tutorials/huggingface/multi-agent', to: '/docs/tutorials/llms/multi-agent' },
-          { from: '/docs/tutorials/huggingface/ocr-vision-language', to: '/docs/tutorials/llms/ocr-vision-language' },
-          { from: '/docs/tutorials/huggingface/online-preference-methods', to: '/docs/tutorials/llms/online-preference-methods' },
-          { from: '/docs/tutorials/huggingface/overview', to: '/docs/tutorials/llms/overview' },
-          { from: '/docs/tutorials/huggingface/preference-optimization', to: '/docs/tutorials/llms/preference-optimization' },
-          { from: '/docs/tutorials/huggingface/qwen38-hybrid-attention', to: '/docs/tutorials/llms/qwen38-hybrid-attention' },
-          { from: '/docs/tutorials/huggingface/rlhf-reward-modeling', to: '/docs/tutorials/llms/rlhf-reward-modeling' },
-          { from: '/docs/tutorials/huggingface/trl-function-calling', to: '/docs/tutorials/llms/trl-function-calling' }
-        ],
-      },
-    ],
-  ],
-
   // iOS ignores <link rel="icon"> for "Add to Home Screen". Without an
   // apple-touch-icon it renders a letter tile instead of the logo -- which is
   // why the site showed a bare "D". These tags are what fix that, and they must

--- a/docusaurus-docs/package.json
+++ b/docusaurus-docs/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.6.3",
-    "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/preset-classic": "^3.6.3",
     "@docusaurus/theme-mermaid": "^3.6.3",
     "@easyops-cn/docusaurus-search-local": "^0.44.5",


### PR DESCRIPTION
Reverses the redirect half of #13 at the owner's direction. The reasoning is sound: the point of renaming the section was to stop the course being addressed as "huggingface", and 15 forwarding paths kept that name alive in the URL space.

## What was actually there

Worth being precise, since *"the old URL still works"* and *"the old page still exists"* are different claims. Each stub was a **415-byte file** containing only:

```html
<meta http-equiv="refresh" content="0; url=/deepspeed-course/docs/tutorials/llms/deepseek-mla">
<link rel="canonical" href="/deepspeed-course/docs/tutorials/llms/deepseek-mla" />
```

No content, no duplicate page. The sitemap advertised **zero** of them, nothing in the repo linked to them, and a reader following one landed on `/llms/` with `/llms/` in the address bar.

## Why removing is cheap here

They protected stale inbound links. The only ones known to exist are **three URLs handed to the Clawdeck session earlier today** — corrected in the handover at no cost. A clean break is cheap for a rename that is hours old in a way it would not be for URLs public for months.

## Result

Plugin and dependency removed. The build emits `/llms/` and nothing else — `build/docs/tutorials/huggingface` no longer exists. Old URLs 404, which is now the **intended** outcome rather than an oversight.

27 suites · docs build clean · 15/15 pages at the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa