### PR TITLE
fix: Rank-guard the CIFAR-10 download, which raced on a cold 2-GPU box

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Multi-head Latent Attention
         run: uv run tests/test_mla.py
 
+      - name: Multi-GPU labs rank-guard their downloads
+        run: uv run tests/test_multigpu_download_guard.py
+
       - name: Every training script compiles
         run: |
           uv run --no-project python -m compileall -q \

--- a/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
+++ b/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
@@ -147,14 +147,47 @@ class CIFAR10CNNEnhanced(nn.Module):
 
 def download_cifar10():
     """
-    Download CIFAR-10 dataset once before distributed training.
-    This prevents multiple processes from downloading simultaneously.
+    Download CIFAR-10 once, on rank 0 only, then release the other ranks.
+
+    torchvision's ``download=True`` does no locking. Under
+    ``deepspeed --num_gpus=2`` both ranks run this function, write the same
+    170 MB tarball into the same ``./data``, and extract over each other. The
+    integrity check then fails for BOTH with the thoroughly misleading
+    "Dataset not found or corrupted" — on a file that downloaded fine, twice.
+    The tell is two interleaved progress bars both reaching 170M.
+
+    The barrier matters as much as the guard. Without it rank 1 skips the
+    download and races ahead to read a directory rank 0 is still writing,
+    which fails the same way but only sometimes — far worse to debug.
+
+    ``deepspeed.init_distributed()`` is called here because this runs *before*
+    ``deepspeed.initialize()``, so no process group exists yet and there would
+    be nothing to barrier on. The whole block is gated on ``world_size > 1``
+    so single-GPU and ALLOW_CPU runs never touch the distributed machinery.
+
+    This mirrors the guard in ``train_modern_cifar10.py`` in this same folder.
     """
-    print(f"\n📥 Downloading CIFAR-10 dataset...")
-    # Download without transforms (faster)
-    torchvision.datasets.CIFAR10(root='./data', train=True, download=True)
-    torchvision.datasets.CIFAR10(root='./data', train=False, download=True)
-    print(f"✅ CIFAR-10 dataset ready")
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    is_main = int(os.environ.get("RANK", "0")) == 0
+
+    # No process group exists yet, so create one to barrier on. Single-GPU and
+    # ALLOW_CPU runs skip this entirely and never touch distributed machinery.
+    if world_size > 1 and not torch.distributed.is_initialized():
+        deepspeed.init_distributed()
+
+    if is_main:
+        print(f"\n📥 Downloading CIFAR-10 dataset...")
+        # Download without transforms (faster)
+        torchvision.datasets.CIFAR10(root='./data', train=True, download=True)
+        torchvision.datasets.CIFAR10(root='./data', train=False, download=True)
+        print(f"✅ CIFAR-10 dataset ready")
+    else:
+        print(f"\n⏳ Rank {os.environ.get('RANK')}: waiting for rank 0 to download...")
+
+    # Every rank reaches this line; the non-zero ranks block here until rank 0
+    # has finished writing AND extracting the archive.
+    if world_size > 1:
+        torch.distributed.barrier()
 
 
 def get_cifar10_dataloaders(batch_size: int = 32):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ passed on all of them. Established patterns to copy:
   (catastrophic cancellation), so exact equality is the wrong test.
 
 ```bash
-./tests/run_all.sh              # all 27 suites, no GPU, no downloads
+./tests/run_all.sh              # all 28 suites, no GPU, no downloads
 uv run tests/test_ds_configs.py # one suite
 ```
 
@@ -412,6 +412,47 @@ report.
 `tests/test_torch_index_pins.py` guards it by reading the **lock**, not the
 pyproject — the resolution rather than the declaration — so a lock regenerated
 against a different index fails even while `pyproject.toml` still looks right.
+
+### Only rank 0 downloads, and the others must wait on a barrier
+
+`01_basics/03_convnet_cifar10` had a `download_cifar10()` whose docstring read
+*"This prevents multiple processes from downloading simultaneously"* and whose
+body did no such thing. Under the lab's own manifest command,
+`deepspeed --num_gpus=2`, both ranks wrote the same 170 MB tarball into the same
+`./data` and extracted over each other:
+
+    RuntimeError: Dataset not found or corrupted. You can use download=True ...
+
+— a spectacularly misleading message for a file that downloaded fine, twice. The
+tell is **two interleaved progress bars both reaching 170M**.
+
+`torchvision.datasets.*(download=True)` does **no locking.** HuggingFace
+`from_pretrained` / `snapshot_download` / `load_dataset` go through
+`huggingface_hub`, which takes `.lock` files and survives concurrency — so this
+is specific to the torchvision path, not a general claim about downloads.
+
+Three things make it worth a static check:
+
+- **It passes on one GPU.** A single rank cannot race itself, so every 1-GPU
+  smoke test is green.
+- **It is syntactically valid**, so `compileall` cannot see it.
+- **It was masked for months by an accident.** The data used to be re-hydrated
+  onto the box at boot, so `./data` was already populated and neither rank ever
+  downloaded. Cleaning that up surfaced a race that had always been there.
+
+The barrier matters as much as the guard: without it rank 1 skips the download
+and races ahead to read a directory rank 0 is still writing, which fails only
+*sometimes*. `train_modern_cifar10.py` in the same folder had it right all
+along (`download=is_main`, then `barrier()`) and is the pattern to copy.
+
+`tests/test_multigpu_download_guard.py` enforces it for every lab
+`clawdeck.yaml` declares as `gpu.count > 1`. It is **AST-based, not a grep**,
+and that distinction is the whole point — several scripts here rank-guard their
+*printing* and *checkpoint saving* while downloading unguarded, so a file-wide
+`grep get_rank() == 0` passes them all. It asks instead whether each individual
+download call is lexically inside a rank-gated branch. Its permanent
+counterexamples include the bug exactly as it shipped **and** a file whose rank
+guard sits around the wrong statement.
 
 ### Library API drift is a CI gate, not a runtime surprise
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ repository therefore ships **logic tests** that exercise the code paths without 
 GPU or a model download:
 
 ```bash
-./tests/run_all.sh                  # 27 suites, no GPU and no downloads
+./tests/run_all.sh                  # 28 suites, no GPU and no downloads
 uv run tests/test_ds_configs.py     # a single suite
 ```
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -46,6 +46,7 @@ TESTS=(
     tests/test_torch_index_pins.py
     tests/test_synthetic_data_is_learnable.py
     tests/test_mla.py
+    tests/test_multigpu_download_guard.py
 )
 
 for test in "${TESTS[@]}"; do

--- a/tests/test_multigpu_download_guard.py
+++ b/tests/test_multigpu_download_guard.py
@@ -1,0 +1,286 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml"]
+# ///
+"""
+Regression test: multi-GPU labs must not download a dataset from every rank.
+
+Run:
+    uv run tests/test_multigpu_download_guard.py
+
+Why this suite exists
+---------------------
+`01_basics/03_convnet_cifar10` shipped a `download_cifar10()` whose docstring
+said "This prevents multiple processes from downloading simultaneously" and
+whose body did nothing of the kind. Under the lab's own manifest command,
+`deepspeed --num_gpus=2`, both ranks wrote the same 170 MB tarball into the
+same `./data` and extracted over each other. torchvision's integrity check
+then failed for BOTH with:
+
+    RuntimeError: Dataset not found or corrupted. You can use download=True ...
+
+which is a spectacularly misleading message for a file that downloaded fine,
+twice. The tell is two interleaved progress bars both reaching 170M.
+
+Three properties make this worth a static check rather than a runtime one:
+
+  * **It passes on one GPU.** A single rank cannot race itself, so every
+    local smoke test and every 1-GPU CI job is green.
+  * **It is syntactically valid**, so `compileall` cannot see it.
+  * **It was masked for months by an accident.** The data used to be
+    re-hydrated onto the box at boot, so `./data` was already populated and
+    neither rank ever downloaded. When that was cleaned up, the race surfaced
+    on the first genuinely cold 2-GPU run. Nothing in the repo changed.
+
+Scope, deliberately narrow
+--------------------------
+This checks `torchvision`-style downloads — a `download=` keyword — because
+those do **no locking**. HuggingFace `from_pretrained` / `snapshot_download` /
+`load_dataset` go through `huggingface_hub`, which takes `.lock` files and
+survives concurrency on a normal filesystem. Flagging those too would produce
+six findings that are not bugs, and a checker that cries wolf gets muted.
+
+Why this is AST-based and not a grep
+------------------------------------
+The obvious implementation is
+
+    assert re.search(r"get_rank\(\) == 0|is_main_process", src)
+
+and it is the same mistake this repo has now made three times: keying on the
+**presence** of a guard rather than on whether the guard actually governs the
+dangerous call. Several scripts here carry rank guards around *printing* and
+*checkpoint saving* while downloading unguarded — a file-wide grep passes all
+of them. So this walks the tree and asks whether each individual download call
+is lexically inside a rank- or world-size-gated branch, or has a rank-derived
+`download=` argument.
+
+The counterexamples at the bottom are permanent. A checker that has not been
+watched rejecting bad input is not a checker.
+"""
+
+import ast
+import pathlib
+import sys
+
+import yaml
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+# Names that indicate a condition is about which rank we are, or how many
+# processes exist. A download gated on any of these is not a free-for-all.
+RANK_NAMES = {
+    "rank", "local_rank", "global_rank", "world_size", "is_main", "is_master",
+    "is_main_process", "is_rank_zero", "is_local_main_process",
+    "RANK", "LOCAL_RANK", "WORLD_SIZE",
+}
+RANK_CALLS = {"get_rank", "get_local_rank", "get_world_size", "is_initialized"}
+
+PASS = FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}")
+        if detail:
+            for line in detail.splitlines():
+                print(f"          {line}")
+
+
+def mentions_rank(node: ast.AST) -> bool:
+    """True if an expression consults the rank or the world size."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and sub.id in RANK_NAMES:
+            return True
+        if isinstance(sub, ast.Constant) and sub.value in RANK_NAMES:
+            return True   # os.environ.get("RANK", ...)
+        if isinstance(sub, ast.Attribute) and sub.attr in RANK_CALLS:
+            return True
+        if isinstance(sub, ast.Call):
+            f = sub.func
+            if isinstance(f, ast.Name) and f.id in RANK_CALLS:
+                return True
+    return False
+
+
+def unguarded_downloads(src: str) -> list[tuple[int, str]]:
+    """
+    Return (lineno, reason) for every download call NOT governed by a rank or
+    world-size condition.
+
+    A call is considered governed when either
+
+      (a) its ``download=`` argument is itself rank-derived
+          (``download=is_main`` — the pattern in train_modern_cifar10.py), or
+      (b) it sits lexically inside an ``if``/``else`` whose test consults the
+          rank or the world size.
+
+    Walking is done with an explicit guard stack rather than ast.walk(), so a
+    call nested several blocks deep inside a rank check is still seen as
+    guarded. (An earlier checker in this repo recursed into a node's children
+    and thereby never tested statements that were themselves block members —
+    it silently passed everything.)
+    """
+    findings: list[tuple[int, str]] = []
+
+    def visit(node: ast.AST, guarded: bool) -> None:
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "download":
+                    literal_true = (isinstance(kw.value, ast.Constant)
+                                    and kw.value.value is True)
+                    if literal_true and not guarded:
+                        findings.append(
+                            (node.lineno,
+                             "download=True with no enclosing rank/world_size guard"))
+            for child in ast.iter_child_nodes(node):
+                visit(child, guarded)
+            return
+
+        if isinstance(node, ast.If):
+            inner = guarded or mentions_rank(node.test)
+            for stmt in node.body:
+                visit(stmt, inner)
+            for stmt in node.orelse:
+                visit(stmt, inner)
+            visit(node.test, guarded)
+            return
+
+        for child in ast.iter_child_nodes(node):
+            visit(child, guarded)
+
+    visit(ast.parse(src), False)
+    return findings
+
+
+def has_barrier(src: str) -> bool:
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Attribute) and f.attr == "barrier":
+                return True
+            if isinstance(f, ast.Name) and f.id == "barrier":
+                return True
+    return False
+
+
+def multi_gpu_labs() -> list[str]:
+    manifest = yaml.safe_load((REPO / "clawdeck.yaml").read_text())
+    labs = manifest.get("labs", manifest) if isinstance(manifest, dict) else manifest
+    out = []
+    for lab in labs:
+        if not isinstance(lab, dict):
+            continue
+        gpu = lab.get("gpu") or {}
+        if int(gpu.get("count", 1) or 1) > 1:
+            out.append(lab["id"])
+    return out
+
+
+def main() -> None:
+    bar = "=" * 74
+    print(bar)
+    print("  test_multigpu_download_guard.py")
+    print(bar)
+
+    labs = multi_gpu_labs()
+    print(f"\n  -- {len(labs)} labs declared multi-GPU in clawdeck.yaml --")
+    for lab in labs:
+        print(f"     {lab}")
+
+    print("\n  -- no unguarded download in a multi-GPU lab --")
+    checked = 0
+    for lab in labs:
+        for py in sorted((REPO / lab).glob("*.py")):
+            src = py.read_text(errors="ignore")
+            if "download" not in src:
+                continue
+            checked += 1
+            bad = unguarded_downloads(src)
+            rel = py.relative_to(REPO)
+            detail = "\n".join(
+                f"{rel}:{ln}  {why}" for ln, why in bad) + (
+                "\n\nOnly rank 0 may download; the others must wait on a "
+                "barrier. torchvision does no locking, so two ranks writing "
+                "one directory corrupt it and BOTH then fail the integrity "
+                "check. See download_cifar10() in "
+                "01_basics/03_convnet_cifar10/cifar10_deepspeed.py."
+            )
+            check(f"{rel}", not bad, detail if bad else "")
+
+            if not bad and any(
+                    kw.arg == "download"
+                    for n in ast.walk(ast.parse(src))
+                    if isinstance(n, ast.Call) for kw in n.keywords):
+                check(f"{rel} also barriers, so the waiters actually wait",
+                      has_barrier(src),
+                      "A rank guard WITHOUT a barrier is worse than no guard: "
+                      "rank 1 skips the download and races ahead to read a "
+                      "directory rank 0 is still writing. That fails only "
+                      "sometimes, which is far harder to debug.")
+    print(f"\n     ({checked} files mentioning a download were parsed)")
+
+    # ---- the counterexamples ------------------------------------------------
+    # Without these, a checker that returned [] unconditionally would pass
+    # everything above and look perfect.
+    print("\n  -- the checker can actually reject bad input --")
+
+    exact_shipped_bug = '''
+import torchvision
+def download_cifar10():
+    """This prevents multiple processes from downloading simultaneously."""
+    torchvision.datasets.CIFAR10(root='./data', train=True, download=True)
+'''
+    check("flags the bug as it actually shipped",
+          len(unguarded_downloads(exact_shipped_bug)) == 1,
+          "this is the verbatim shape of the code that failed on a 2-GPU box")
+
+    guard_elsewhere = '''
+import torchvision, torch.distributed as dist
+def main():
+    if dist.get_rank() == 0:
+        print("only rank 0 prints")
+    torchvision.datasets.CIFAR10(root='./data', download=True)
+'''
+    check("flags a download whose file HAS a rank guard, just not around it",
+          len(unguarded_downloads(guard_elsewhere)) == 1,
+          "this is precisely the case a grep-based check passes; if this ever "
+          "returns 0 the checker has degraded to presence-matching")
+
+    nested_deep = '''
+import torchvision
+def main():
+    if world_size > 1:
+        if is_main:
+            for split in (True, False):
+                torchvision.datasets.CIFAR10(root='./d', train=split, download=True)
+'''
+    check("does NOT flag a download nested several blocks inside a guard",
+          unguarded_downloads(nested_deep) == [],
+          "over-flagging a correct lab trains people to ignore the checker")
+
+    kwarg_derived = '''
+import torchvision
+ds = torchvision.datasets.CIFAR10(root='./d', download=is_main)
+'''
+    check("does NOT flag download=is_main (train_modern_cifar10.py's pattern)",
+          unguarded_downloads(kwarg_derived) == [],
+          "the rank test can live in the argument rather than in an if")
+
+    check("barrier detection rejects a file with no barrier",
+          not has_barrier(exact_shipped_bug))
+    check("barrier detection accepts torch.distributed.barrier()",
+          has_barrier("import torch\ntorch.distributed.barrier()\n"))
+
+    print("\n" + bar)
+    print(f"  {PASS} passed, {FAIL} failed")
+    print(bar)
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reported from a Clawdeck box: `uv run deepspeed --num_gpus=2 cifar10_deepspeed.py --max-steps 20` fails on a cold machine with `RuntimeError: Dataset not found or corrupted`, after two interleaved progress bars both reach 170M.

## The bug

`download_cifar10()` had this docstring:

> This prevents multiple processes from downloading simultaneously.

and a body that did nothing of the kind. Both ranks wrote the same tarball into the same `./data` and extracted over each other, so torchvision's integrity check failed for **both** — on a file that downloaded fine, twice.

It was always there. It was masked because the dataset used to be re-hydrated onto the box at boot, so `./data` was pre-populated and neither rank ever downloaded. This is the first genuinely cold 2-GPU run; nothing in this repo changed to cause it.

## One correction to the report

The suggested fix was `rank = dist.get_rank() if dist.is_initialized() else 0`. That is a **no-op here**: `download_cifar10()` runs at line 314, before `deepspeed.initialize()` at line 346, so `dist.is_initialized()` is `False` on every rank — all of them compute `rank = 0`, all of them download, and no barrier executes. It would have looked correct and changed nothing.

So the fix calls `deepspeed.init_distributed()` first to create a group to barrier on, gated on `WORLD_SIZE > 1` so single-GPU and `ALLOW_CPU` runs never touch distributed machinery. This is the pattern `train_modern_cifar10.py` **in the same folder** has used all along.

## The other six labs: audited, not affected

All use HF `from_pretrained` / `load_dataset`, which lock via `huggingface_hub`. The torchvision path is the only unlocked download in the repo — confirmed by grepping every `download=` call site.

## The CI guard

`tests/test_multigpu_download_guard.py`, over every lab `clawdeck.yaml` declares `gpu.count > 1`.

**AST-based, not a grep.** The suggested `assert re.search(r"get_rank\(\) == 0", src)` keys on the *presence* of a guard rather than whether it governs the download — and several scripts here rank-guard their printing and checkpoint saving while downloading unguarded, so that grep passes all of them. This asks whether each individual download call is lexically inside a rank-gated branch, or has a rank-derived `download=` argument.

Run against the unfixed tree first, where it named the exact file and lines:

```
FAIL  01_basics/03_convnet_cifar10/cifar10_deepspeed.py
        cifar10_deepspeed.py:155  download=True with no enclosing rank/world_size guard
        cifar10_deepspeed.py:156  download=True with no enclosing rank/world_size guard
```

Permanent counterexamples: the bug exactly as it shipped, and a file whose rank guard sits around the wrong statement (the case a grep passes). Plus two negative cases so it cannot degrade into over-flagging.

The repo's own meta-test then caught that I owed it a CI registration and a suite-count bump — 27 → 28.

All 28 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa