### PR TITLE
fix: Bind each rank's device before the download barrier, which hung on cuda:0

### DIFF
--- a/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
+++ b/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
@@ -25,6 +25,7 @@ import deepspeed
 import sys
 import argparse
 import os
+from datetime import timedelta
 
 # Optional Weights & Biases integration
 try:
@@ -168,12 +169,29 @@ def download_cifar10():
     This mirrors the guard in ``train_modern_cifar10.py`` in this same folder.
     """
     world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
     is_main = int(os.environ.get("RANK", "0")) == 0
 
-    # No process group exists yet, so create one to barrier on. Single-GPU and
-    # ALLOW_CPU runs skip this entirely and never touch distributed machinery.
-    if world_size > 1 and not torch.distributed.is_initialized():
-        deepspeed.init_distributed()
+    if world_size > 1:
+        # Bind this rank to its own GPU BEFORE issuing any collective.
+        #
+        # NCCL implements barrier() as an all-reduce of a one-element tensor,
+        # so it has to put that tensor somewhere. torch picks the device by
+        # checking, in order: (1) barrier(device_ids=...), (2) the device bound
+        # at init_process_group, (3) CPU, and failing all three (4) "the current
+        # device" -- which, with nothing set, is cuda:0 on EVERY rank. Both
+        # ranks then post the collective to the same GPU and NCCL simply hangs
+        # until the 600 s watchdog aborts the job. torch's own source warns
+        # about this case in as many words.
+        #
+        # deepspeed.initialize() would assign the device for us, but this code
+        # runs before it on purpose, so it has to be done here.
+        if torch.cuda.is_available():
+            torch.cuda.set_device(local_rank)
+        # No process group exists yet, so create one to barrier on. Single-GPU
+        # and ALLOW_CPU runs skip all of this and never touch distributed.
+        if not torch.distributed.is_initialized():
+            deepspeed.init_distributed()
 
     if is_main:
         print(f"\n📥 Downloading CIFAR-10 dataset...")
@@ -186,8 +204,18 @@ def download_cifar10():
 
     # Every rank reaches this line; the non-zero ranks block here until rank 0
     # has finished writing AND extracting the archive.
+    #
+    # device_ids pins the collective explicitly rather than relying on the
+    # set_device above -- belt and braces, and it makes the choice visible to a
+    # reader. The timeout is per-CALL, not on the process group: a genuine
+    # rendezvous failure here surfaces in two minutes instead of the twelve
+    # that NCCL's default takes, while training keeps the normal 10-minute
+    # budget for its own collectives.
     if world_size > 1:
-        torch.distributed.barrier()
+        torch.distributed.barrier(
+            device_ids=[local_rank] if torch.cuda.is_available() else None,
+            timeout=timedelta(seconds=120),
+        )
 
 
 def get_cifar10_dataloaders(batch_size: int = 32):

--- a/01_basics/03_convnet_cifar10/train_modern_cifar10.py
+++ b/01_basics/03_convnet_cifar10/train_modern_cifar10.py
@@ -49,6 +49,7 @@ CONTRIBUTING.md warns about.
 
 import os
 import sys
+from datetime import timedelta
 
 
 def require_gpu() -> None:
@@ -206,6 +207,16 @@ def main() -> None:
         images, labels = next(iter(loader))
         return images, labels
 
+    # Bind this rank to its own GPU BEFORE any collective is issued. NCCL's
+    # barrier is an all-reduce of a one-element tensor and, with no device set
+    # and no device_ids passed, torch falls back to "the current device" --
+    # cuda:0 on every rank. Both ranks then post to the same GPU and NCCL hangs
+    # until the watchdog aborts. This used to sit six lines below the barrier,
+    # which was a real hang waiting for the first cold multi-GPU run.
+    device = torch.device(f"cuda:{max(args.local_rank, 0)}")
+    if torch.cuda.is_available():
+        torch.cuda.set_device(device)
+
     if world_size > 1:
         # Only rank 0 downloads; everyone else waits, or they race on the same
         # files and one of them reads a half-written archive.
@@ -213,13 +224,15 @@ def main() -> None:
             deepspeed.init_distributed()
         if is_main:
             as_tensors(True), as_tensors(False)
-        torch.distributed.barrier()
+        # Explicit device_ids, and a per-call timeout so a rendezvous failure
+        # surfaces in two minutes rather than twelve.
+        torch.distributed.barrier(
+            device_ids=[max(args.local_rank, 0)] if torch.cuda.is_available() else None,
+            timeout=timedelta(seconds=120),
+        )
 
     train_x, train_y = as_tensors(True)
     test_x, test_y = as_tensors(False)
-
-    device = torch.device(f"cuda:{max(args.local_rank, 0)}")
-    torch.cuda.set_device(device)
     train_x = ((train_x - mean) / std).to(device)
     train_y = train_y.to(device)
     test_x = ((test_x - mean) / std).to(device)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,7 +445,28 @@ and races ahead to read a directory rank 0 is still writing, which fails only
 *sometimes*. `train_modern_cifar10.py` in the same folder had it right all
 along (`download=is_main`, then `barrier()`) and is the pattern to copy.
 
-`tests/test_multigpu_download_guard.py` enforces it for every lab
+**Fixing it exposed a second bug, in the fix itself.** The guard worked — rank 1
+waited, the download happened once — and the job then died twelve minutes later
+*in the barrier*, `ALLREDUCE` with `NumelIn=1` running for 721,595 ms. NCCL
+implements `barrier()` as an all-reduce of a one-element tensor, so it must pick
+a device, and torch chooses: (1) `barrier(device_ids=)`, (2) the device bound at
+`init_process_group`, (3) CPU, else (4) **the current device — cuda:0 on every
+rank.** torch's own source warns this "may use default device 0, causing issues
+like hang or all processes creating context on device 0."
+
+`deepspeed.initialize()` normally binds the device for you. **A download guard
+runs before `initialize()` by design, so it is precisely the window where this
+bites.** Call `torch.cuda.set_device(local_rank)` before the collective and pass
+`device_ids=` to the barrier. Note also that `barrier()` takes a **per-call**
+`timeout`, so the guard can fail in two minutes without shortening the process
+group that training then reuses for ten-minute collectives.
+
+`train_modern_cifar10.py` — held up above as the reference — had the same latent
+defect, `set_device` sitting *six lines below* its barrier. It had simply never
+been run cold on two GPUs. Copying a sibling is only as safe as the sibling's
+test coverage.
+
+`tests/test_multigpu_download_guard.py` enforces both properties for every lab
 `clawdeck.yaml` declares as `gpu.count > 1`. It is **AST-based, not a grep**,
 and that distinction is the whole point — several scripts here rank-guard their
 *printing* and *checkpoint saving* while downloading unguarded, so a file-wide

--- a/tests/test_multigpu_download_guard.py
+++ b/tests/test_multigpu_download_guard.py
@@ -157,6 +157,59 @@ def unguarded_downloads(src: str) -> list[tuple[int, str]]:
     return findings
 
 
+def unbound_barriers(src: str) -> list[tuple[int, str]]:
+    """
+    Return (lineno, reason) for every ``barrier()`` that may land on cuda:0 for
+    all ranks at once.
+
+    Found the hard way, on the very fix that closed the download race. The
+    guard worked -- rank 1 waited, the download happened once -- and then the
+    job died 12 minutes later in the barrier itself:
+
+        WorkNCCL(SeqNum=1, OpType=ALLREDUCE, NumelIn=1, NumelOut=1)
+          ran for 721595 milliseconds before timing out
+
+    NCCL implements barrier as an all-reduce of a one-element tensor, so it
+    must choose a device. torch picks, in order: (1) ``barrier(device_ids=)``,
+    (2) the device bound at ``init_process_group``, (3) CPU, and failing those
+    (4) *the current device* -- which, with nothing set, is cuda:0 on EVERY
+    rank. torch's own source says this "may use default device 0, causing
+    issues like hang or all processes creating context on device 0."
+
+    Normally ``deepspeed.initialize()`` binds the device for you. A download
+    guard that runs *before* initialize() -- which is the whole point of a
+    download guard -- is therefore exactly the window where this bites.
+
+    So: a barrier is safe if it passes ``device_ids``, or if a ``set_device``
+    call appears earlier in the file. Line order is a sound proxy here because
+    both live in the same straight-line preamble.
+    """
+    tree = ast.parse(src)
+    set_device_lines = [
+        n.lineno for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute) and n.func.attr == "set_device"
+    ]
+    findings = []
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.Call):
+            continue
+        f = n.func
+        is_barrier = (isinstance(f, ast.Attribute) and f.attr == "barrier") or \
+                     (isinstance(f, ast.Name) and f.id == "barrier")
+        if not is_barrier:
+            continue
+        if any(kw.arg == "device_ids" for kw in n.keywords):
+            continue
+        if any(ln < n.lineno for ln in set_device_lines):
+            continue
+        findings.append(
+            (n.lineno,
+             "barrier() with no device_ids and no earlier set_device — "
+             "every rank may post the all-reduce to cuda:0 and hang"))
+    return findings
+
+
 def has_barrier(src: str) -> bool:
     for node in ast.walk(ast.parse(src)):
         if isinstance(node, ast.Call):
@@ -224,6 +277,23 @@ def main() -> None:
                       "sometimes, which is far harder to debug.")
     print(f"\n     ({checked} files mentioning a download were parsed)")
 
+    print("\n  -- every barrier names its device, or binds one first --")
+    for lab in labs:
+        for py in sorted((REPO / lab).glob("*.py")):
+            src = py.read_text(errors="ignore")
+            if "barrier" not in src:
+                continue
+            bad = unbound_barriers(src)
+            rel = py.relative_to(REPO)
+            detail = "\n".join(f"{rel}:{ln}  {why}" for ln, why in bad) + (
+                "\n\nPass device_ids=[local_rank], or call "
+                "torch.cuda.set_device(local_rank) BEFORE the collective. "
+                "deepspeed.initialize() would do it for you, but a download "
+                "guard runs before initialize() by design — which is exactly "
+                "when this hangs for 12 minutes and then SIGABRTs."
+            )
+            check(f"{rel}", not bad, detail if bad else "")
+
     # ---- the counterexamples ------------------------------------------------
     # Without these, a checker that returned [] unconditionally would pass
     # everything above and look perfect.
@@ -270,6 +340,34 @@ ds = torchvision.datasets.CIFAR10(root='./d', download=is_main)
     check("does NOT flag download=is_main (train_modern_cifar10.py's pattern)",
           unguarded_downloads(kwarg_derived) == [],
           "the rank test can live in the argument rather than in an if")
+
+    # The second bug, caught on real 2-GPU hardware by the fix for the first.
+    naked_barrier = '''
+import torch
+if world_size > 1:
+    deepspeed.init_distributed()
+torch.distributed.barrier()
+'''
+    check("flags a barrier with no device_ids and no set_device",
+          len(unbound_barriers(naked_barrier)) == 1,
+          "this shape hung for 721 s on 2x3090 and then SIGABRTed")
+
+    set_device_too_late = '''
+import torch
+torch.distributed.barrier()
+torch.cuda.set_device(local_rank)
+'''
+    check("flags set_device that comes AFTER the barrier",
+          len(unbound_barriers(set_device_too_late)) == 1,
+          "train_modern_cifar10.py had set_device six lines BELOW its barrier; "
+          "an order-insensitive check would have called that file correct")
+
+    check("does NOT flag a barrier that passes device_ids",
+          unbound_barriers(
+              "import torch\ntorch.distributed.barrier(device_ids=[0])\n") == [])
+    check("does NOT flag a barrier preceded by set_device",
+          unbound_barriers("import torch\ntorch.cuda.set_device(0)\n"
+                           "torch.distributed.barrier()\n") == [])
 
     check("barrier detection rejects a file with no barrier",
           not has_barrier(exact_shipped_bug))


### PR DESCRIPTION
Follow-up to #16, from a verified cold 2×RTX 3090 run.

## The download fix works — confirmed on hardware

Rank 1 printed the waiting line, exactly one 170 MB download occurred, and no corruption. The race is dead.

## But the barrier it added then hung

```
WorkNCCL(SeqNum=1, OpType=ALLREDUCE, NumelIn=1, NumelOut=1, Timeout(ms)=600000)
  ran for 721595 milliseconds before timing out
```

Rank 0 had already printed `✅ CIFAR-10 dataset ready`, so the download was not the holdup. Both ranks reached the barrier and failed to rendezvous.

## Mechanism — verified in source, not assumed

NCCL implements `barrier()` as an all-reduce of a one-element tensor, so it must choose a device. `torch/distributed/distributed_c10d.py` picks, in order: (1) `barrier(device_ids=)`, (2) the device bound at `init_process_group`, (3) CPU, else (4) the current device — with this comment:

> Use the current device set by the user. If user did not set any, this **may use default device 0, causing issues like hang or all processes creating context on device 0.**

I also confirmed `deepspeed/comm/comm.py::init_distributed()` contains **no** `set_device` call — DeepSpeed binds the device in `initialize()`, which a download guard runs before by design. That is exactly the window.

## Two corrections to the report

**The sibling does not "get away with it".** `train_modern_cifar10.py` had `barrier()` at line 216 and `set_device` at line 222 — six lines too late. Same latent bug; it had simply never been run cold on two GPUs, since the manifest only runs `cifar10_deepspeed.py`. Fixed here too. Copying a sibling is only as safe as the sibling's test coverage.

**The timeout goes on the call, not the group.** `barrier()` accepts a per-call `timeout=`, so the guard fails in 2 minutes while training keeps the default 10-minute budget. Passing `timeout=` to `init_distributed()` as suggested would have shortened *every* collective for the whole run — a spurious-abort risk during training.

## The CI guard

`unbound_barriers()` flags any `barrier()` with no `device_ids` and no earlier `set_device`. Against the pre-fix tree:

```
FAIL  cifar10_deepspeed.py:190     barrier() with no device_ids and no earlier set_device
FAIL  train_modern_cifar10.py:216  barrier() with no device_ids and no earlier set_device
```

Counterexamples include `set_device` placed *after* the barrier — an order-insensitive check would have called `train_modern_cifar10.py` correct. Two negative cases guard against over-flagging; other labs with barriers pass untouched.

All 28 suites pass. **Still needs a cold 2-GPU re-run to confirm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa