### PR TITLE
test: Add a 10-second probe for per-rank GPU binding

### DIFF
--- a/tests/gpu/README.md
+++ b/tests/gpu/README.md
@@ -71,6 +71,40 @@ The fix unwraps the batch dimension, and
 `tests/test_video_frames.py` now guards it **on CPU** with a fake processor that
 reproduces the nested shape — so the regression is caught in CI, without a GPU.
 
+## `probe_device_binding.py`
+
+```bash
+uv run deepspeed --num_gpus=2 tests/gpu/probe_device_binding.py
+```
+
+Ten seconds, no dataset, no model. Answers one question: **does each rank bind
+to its own GPU before the first collective?**
+
+Run it when a multi-GPU job hangs in a barrier near startup, before spending
+twenty minutes on a real training run. NCCL implements `barrier()` as an
+all-reduce of a one-element tensor and must pick a device for it; with nothing
+set and no `device_ids` passed, torch falls back to "the current device", which
+is **cuda:0 on every rank**, and the job hangs until the watchdog aborts.
+
+`deepspeed.initialize()` normally binds the device. Anything running *before*
+it — a dataset download guard, say — is exactly the window where this bites.
+`deepspeed.init_distributed()` does not bind it.
+
+| Output | Meaning |
+|---|---|
+| `current_device=0` and `=1`, both ranks pass | healthy |
+| both ranks report `current_device=0` | `set_device` is not taking; check the launcher exports `LOCAL_RANK` |
+| correct devices but hangs at the barrier | binding is fine, the interconnect is not — go to `diagnose_nccl.sh` |
+
+### The bug it found
+
+`01_basics/03_convnet_cifar10` was fixed so only rank 0 downloads CIFAR-10 and
+the others wait on a barrier. The guard worked — and the job then died twelve
+minutes later *inside that barrier*, `ALLREDUCE` with `NumelIn=1` running for
+721,595 ms. The fix (`set_device` before the collective, `device_ids=` on the
+barrier) is now enforced statically by
+`tests/test_multigpu_download_guard.py`.
+
 ## Adding a GPU script
 
 - Skip with exit 0 when `torch.cuda.is_available()` is false.

--- a/tests/gpu/probe_device_binding.py
+++ b/tests/gpu/probe_device_binding.py
@@ -1,0 +1,108 @@
+"""
+Does each rank actually bind to its OWN GPU before the first collective?
+
+    uv run deepspeed --num_gpus=2 tests/gpu/probe_device_binding.py
+
+Run this when a multi-GPU job hangs in a barrier near startup, BEFORE spending
+twenty minutes on a real training run. It answers one question in about ten
+seconds and needs no dataset, no model and no download.
+
+Why this exists
+---------------
+`01_basics/03_convnet_cifar10` was fixed so that only rank 0 downloads CIFAR-10
+and the others wait on a barrier. The guard worked. The job then died twelve
+minutes later *in that barrier*:
+
+    WorkNCCL(SeqNum=1, OpType=ALLREDUCE, NumelIn=1, NumelOut=1, Timeout(ms)=600000)
+      ran for 721595 milliseconds before timing out
+
+NCCL implements `barrier()` as an all-reduce of a one-element tensor, so it has
+to choose a device for that tensor. torch chooses by checking, in order:
+
+    1. barrier(device_ids=[...])
+    2. the device bound at init_process_group
+    3. CPU
+    4. "the current device"
+
+and on step 4, with nothing set, that is **cuda:0 on every rank**. torch's own
+source warns this "may use default device 0, causing issues like hang or all
+processes creating context on device 0". Both ranks post to the same GPU and
+NCCL waits forever.
+
+`deepspeed.initialize()` normally binds the device for you. Any code that runs
+*before* initialize() -- a dataset download guard, for instance -- is therefore
+exactly the window where this bites. `deepspeed.init_distributed()` does NOT
+bind it; there is no `set_device` call anywhere in `deepspeed/comm/comm.py`.
+
+Reading the result
+------------------
+Expected on a healthy 2-GPU box:
+
+    RANK=0 LOCAL_RANK=0 current_device=0
+    RANK=1 LOCAL_RANK=1 current_device=1
+    RANK=0 passed the barrier
+    RANK=1 passed the barrier
+
+**Both ranks reporting current_device=0** means `set_device` is not taking, and
+the fault is upstream of the barrier -- check that the launcher is exporting
+LOCAL_RANK (DeepSpeed's launch.py sets RANK, LOCAL_RANK and WORLD_SIZE in each
+child's environment; a launcher that only passes `--local_rank` through argv
+would leave `os.environ["LOCAL_RANK"]` unset and every rank would read the "0"
+default).
+
+**Correct devices but a hang at the barrier** means the device binding is fine
+and the problem is the interconnect rather than the script. Go to
+`tests/gpu/diagnose_nccl.sh`, which walks up from topology to bare NCCL to
+NCCL_P2P_DISABLE=1.
+
+The 60-second timeout is deliberate: a probe that takes ten minutes to tell you
+it failed is not much of a probe.
+"""
+
+import os
+import sys
+from datetime import timedelta
+
+
+def main() -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        print("This probe needs CUDA. It is asking which GPU each rank binds "
+              "to, which is not a question on a CPU-only box.")
+        sys.exit(1)
+
+    import deepspeed
+
+    rank = os.environ.get("RANK", "<unset>")
+    local_rank_env = os.environ.get("LOCAL_RANK")
+    if local_rank_env is None:
+        print("⚠️  LOCAL_RANK is not set in the environment. Every rank will "
+              "read the '0' default and bind to cuda:0 — which is the bug this "
+              "probe looks for. Are you running under the deepspeed launcher?")
+    local_rank = int(local_rank_env or "0")
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+
+    # The line under test. Must happen before ANY collective.
+    torch.cuda.set_device(local_rank)
+
+    deepspeed.init_distributed()
+
+    print(f"RANK={rank} LOCAL_RANK={local_rank} "
+          f"current_device={torch.cuda.current_device()} "
+          f"({torch.cuda.get_device_name(local_rank)})", flush=True)
+
+    if world_size < 2:
+        print("Only one rank — a single process cannot race itself. "
+              "Re-run with --num_gpus=2 for this to mean anything.", flush=True)
+        return
+
+    torch.distributed.barrier(
+        device_ids=[local_rank],
+        timeout=timedelta(seconds=60),
+    )
+    print(f"RANK={rank} passed the barrier", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #17. No change to shipped lab code — this adds a diagnostic only.

## Why

The barrier hang in #17 cost a 19-minute cold 2-GPU run to surface, and twelve of those minutes were NCCL's default timeout elapsing in silence. The symptom is identical whether the fault is the script or the box, and those have completely different fixes.

```bash
uv run deepspeed --num_gpus=2 tests/gpu/probe_device_binding.py
```

Ten seconds, no dataset, no model, no download. 60-second timeout, because a probe that takes ten minutes to report failure is not much of a probe.

| Output | Meaning |
|---|---|
| `current_device=0` and `=1`, both ranks pass | healthy |
| both ranks report `current_device=0` | `set_device` is not taking; fault is upstream of the barrier |
| correct devices but hangs | binding is fine, interconnect is not → `diagnose_nccl.sh` |

## The assumption it checks explicitly

The #17 fix rests entirely on `os.environ["LOCAL_RANK"]` being per-rank. A launcher that only passed `--local_rank` through argv would leave it unset, every rank would read the `"0"` default, bind to cuda:0, and the hang would survive a fix that looks correct.

DeepSpeed's `launch.py` does export `RANK`, `LOCAL_RANK` and `WORLD_SIZE` into each child's environment (lines 241-242) — verified in source — which is why the fix works. The probe warns loudly if that ever stops being true.

Sits alongside `diagnose_nccl.sh` and hands off to it for the interconnect case. Documented in `tests/gpu/README.md`. All 28 CPU suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa