### PR TITLE
fix: Drop barrier(timeout=), which torch 2.11 does not accept

### DIFF
--- a/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
+++ b/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
@@ -25,7 +25,6 @@ import deepspeed
 import sys
 import argparse
 import os
-from datetime import timedelta
 
 # Optional Weights & Biases integration
 try:
@@ -207,14 +206,18 @@ def download_cifar10():
     #
     # device_ids pins the collective explicitly rather than relying on the
     # set_device above -- belt and braces, and it makes the choice visible to a
-    # reader. The timeout is per-CALL, not on the process group: a genuine
-    # rendezvous failure here surfaces in two minutes instead of the twelve
-    # that NCCL's default takes, while training keeps the normal 10-minute
-    # budget for its own collectives.
+    # reader.
+    #
+    # There is deliberately no timeout= here. torch 2.11 (what every lab in
+    # this repo locks) takes only group, async_op and device_ids; the per-call
+    # timeout arrives in 2.13. So this barrier inherits NCCL's 600 s default,
+    # and a genuine rendezvous failure costs ten minutes of silence before the
+    # watchdog fires. If that happens, do not debug it from here -- run
+    # tests/gpu/probe_device_binding.py, which answers the device question in
+    # ten seconds, and then tests/gpu/diagnose_nccl.sh for the interconnect.
     if world_size > 1:
         torch.distributed.barrier(
             device_ids=[local_rank] if torch.cuda.is_available() else None,
-            timeout=timedelta(seconds=120),
         )
 
 

--- a/01_basics/03_convnet_cifar10/train_modern_cifar10.py
+++ b/01_basics/03_convnet_cifar10/train_modern_cifar10.py
@@ -49,7 +49,6 @@ CONTRIBUTING.md warns about.
 
 import os
 import sys
-from datetime import timedelta
 
 
 def require_gpu() -> None:
@@ -224,11 +223,10 @@ def main() -> None:
             deepspeed.init_distributed()
         if is_main:
             as_tensors(True), as_tensors(False)
-        # Explicit device_ids, and a per-call timeout so a rendezvous failure
-        # surfaces in two minutes rather than twelve.
+        # Explicit device_ids. No timeout= -- torch 2.11, which every lab
+        # here locks, does not accept one on barrier(); it lands in 2.13.
         torch.distributed.barrier(
             device_ids=[max(args.local_rank, 0)] if torch.cuda.is_available() else None,
-            timeout=timedelta(seconds=120),
         )
 
     train_x, train_y = as_tensors(True)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,9 +457,15 @@ like hang or all processes creating context on device 0."
 `deepspeed.initialize()` normally binds the device for you. **A download guard
 runs before `initialize()` by design, so it is precisely the window where this
 bites.** Call `torch.cuda.set_device(local_rank)` before the collective and pass
-`device_ids=` to the barrier. Note also that `barrier()` takes a **per-call**
-`timeout`, so the guard can fail in two minutes without shortening the process
-group that training then reuses for ten-minute collectives.
+`device_ids=` to the barrier. There is deliberately **no `timeout=`** on that barrier:
+torch 2.13 accepts one, and **torch 2.11 — what every lab here locks — does
+not.** Passing it raises `TypeError` on the rented GPU after both ranks have
+launched. I shipped exactly that bug by reading the signature out of whichever
+torch a `find` returned first; the uv cache held 2.9, 2.10, 2.11, 2.13 and
+2.14, and only the last two have the parameter. **Verify an API against the
+version the lab's `uv.lock` resolves, not against whatever is on the box.**
+`tests/test_config_kwargs.py` now covers `torch.distributed` free functions for
+this reason, and normalises `2.11.0+cu128` to `2.11.0` when comparing.
 
 `train_modern_cifar10.py` — held up above as the reference — had the same latent
 defect, `set_device` sitting *six lines below* its barrier. It had simply never

--- a/tests/gpu/probe_device_binding.py
+++ b/tests/gpu/probe_device_binding.py
@@ -55,13 +55,16 @@ and the problem is the interconnect rather than the script. Go to
 `tests/gpu/diagnose_nccl.sh`, which walks up from topology to bare NCCL to
 NCCL_P2P_DISABLE=1.
 
-The 60-second timeout is deliberate: a probe that takes ten minutes to tell you
-it failed is not much of a probe.
+Note there is no timeout= on the barrier. torch 2.11 -- what every lab in this
+repo locks -- accepts only group, async_op and device_ids; the per-call timeout
+arrives in 2.13. Passing it raises TypeError, which is how this probe's own
+first version failed. If this probe hangs rather than returning, that IS the
+answer: the ranks are not rendezvousing, and NCCL's 600 s default is what you
+are waiting out. Ctrl-C after a few seconds and go to diagnose_nccl.sh.
 """
 
 import os
 import sys
-from datetime import timedelta
 
 
 def main() -> None:
@@ -97,10 +100,7 @@ def main() -> None:
               "Re-run with --num_gpus=2 for this to mean anything.", flush=True)
         return
 
-    torch.distributed.barrier(
-        device_ids=[local_rank],
-        timeout=timedelta(seconds=60),
-    )
+    torch.distributed.barrier(device_ids=[local_rank])
     print(f"RANK={rank} passed the barrier", flush=True)
 
 

--- a/tests/test_config_kwargs.py
+++ b/tests/test_config_kwargs.py
@@ -4,6 +4,7 @@
 #   "transformers==5.16.1",
 #   "trl==1.12.0",
 #   "peft==0.20.0",
+#   "torch==2.11.0",
 #   "tomli; python_version < '3.11'",
 # ]
 # ///
@@ -71,7 +72,21 @@ SKIP_DIRS = {".venv", "node_modules", "build", ".git", "__pycache__",
 
 # The versions this suite validates against. They must equal what every lab's
 # uv.lock resolves, or the check is testing something no learner runs.
-PINNED = {"transformers": "5.16.1", "trl": "1.12.0", "peft": "0.20.0"}
+PINNED = {"transformers": "5.16.1", "trl": "1.12.0", "peft": "0.20.0",
+          "torch": "2.11.0"}
+
+# Free functions whose keyword arguments are worth checking, not just
+# constructors. torch.distributed.barrier() earned its place: a fix in this
+# repo passed it timeout=, which torch 2.13 accepts and torch 2.11 -- what
+# every lab here locks -- does not. It raised TypeError on rented GPUs after
+# both ranks had launched and rank 0 was 4 MB into a 170 MB download.
+#
+# The mistake underneath was reading the signature out of whichever torch a
+# `find` happened to return first. The cache held 2.9, 2.10, 2.11, 2.13 and
+# 2.14; timeout= exists in the last two only. That is precisely the failure
+# this suite's pin-vs-lock check exists to prevent, so the fix belongs here.
+TORCH_FUNCS = ("barrier", "init_process_group", "all_reduce", "broadcast",
+               "all_gather", "reduce_scatter", "new_group")
 
 PASS = FAIL = 0
 
@@ -114,6 +129,21 @@ def load_constructors() -> dict:
     for n in ("LoraConfig",):
         if hasattr(peft, n):
             add(n, getattr(peft, n))
+
+    # Free functions. Same contract: read the signature off the installed
+    # library so the check tracks the pin rather than a remembered snapshot.
+    import torch.distributed as dist
+    for n in TORCH_FUNCS:
+        fn = getattr(dist, n, None)
+        if fn is None:
+            continue
+        try:
+            sig = inspect.signature(fn)
+        except (ValueError, TypeError):
+            continue
+        var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD
+                     for p in sig.parameters.values())
+        out[n] = (set(sig.parameters), var_kw)
     return out
 
 
@@ -130,9 +160,12 @@ def main() -> None:
 
     # ---- the pins must match what the labs install ------------------------
     print("\n  -- this suite validates the version the labs actually use --")
-    import transformers, trl, peft
+    import transformers, trl, peft, torch
     installed = {"transformers": transformers.__version__,
-                 "trl": trl.__version__, "peft": peft.__version__}
+                 "trl": trl.__version__, "peft": peft.__version__,
+                 # 2.11.0+cu128 and 2.11.0+cu130 are the same API on different
+                 # CUDA builds; the local build need not match the labs' index.
+                 "torch": torch.__version__.split("+")[0]}
     for pkg, want in PINNED.items():
         check(f"{pkg} {installed[pkg]} is the pinned {want}",
               installed[pkg] == want,
@@ -142,6 +175,10 @@ def main() -> None:
     for lock in sorted(REPO.glob("*/*/uv.lock")):
         for pkg, want in PINNED.items():
             got = locked_version(lock, pkg)
+            # torch locks as 2.11.0+cu128; the API is the version, not the
+            # CUDA build, and this suite installs the PyPI wheel.
+            if got is not None:
+                got = got.split("+")[0]
             if got is not None and got != want:
                 drift.append(f"{lock.parent}: {pkg} {got} != {want}")
     check(f"every lab's uv.lock agrees with these pins "
@@ -153,7 +190,7 @@ def main() -> None:
     # ---- the constructors -------------------------------------------------
     print("\n  -- constructors under test --")
     ctors = load_constructors()
-    check(f"loaded {len(ctors)} config constructors", len(ctors) >= 8,
+    check(f"loaded {len(ctors)} config constructors and functions", len(ctors) >= 8,
           f"got {sorted(ctors)}")
     skipped = []
     for name in sorted(ctors):


### PR DESCRIPTION
Follow-up to #17/#18, from a verified cold 2×RTX 3090 run.

## What #17 got right, confirmed on hardware

```
PRE  RANK=1 LOCAL_RANK=1 current_device=0     <- both start on cuda:0 (the old bug)
PRE  RANK=0 LOCAL_RANK=0 current_device=0
POST RANK=1 LOCAL_RANK=1 current_device=1     <- set_device takes
POST RANK=0 LOCAL_RANK=0 current_device=0
```

Download race: fixed. `Dataset not found or corrupted`: gone. 12-minute NCCL watchdog hang: **does not reproduce**.

## What it got wrong

```
TypeError: barrier() got an unexpected keyword argument 'timeout'
```

`barrier()` gained a per-call `timeout` in **torch 2.13**. Every lab here locks **torch 2.11.0+cu128**, where the signature is exactly `(group, async_op, device_ids)`.

I introduced this by reading the signature out of whichever torch a `find` returned first. The uv cache holds 2.9, 2.10, 2.11, 2.13 and 2.14 — only the last two have the parameter. Verified against the locked version:

```
torch 2.11.0  barrier ['group', 'async_op', 'device_ids']
```

The reasoning for wanting it there was sound; the API does not offer it at this pin.

## The fix

Dropped, not moved to `init_distributed()` — on the group it would shorten every *training* collective. The barrier works now, so NCCL's 600 s default only costs on a genuine rendezvous failure, and the comment points at `probe_device_binding.py` for the ten-second answer instead.

Fixed in all three call sites — including `tests/gpu/probe_device_binding.py`, which carried the same bug. The probe written to catch this class of failure would itself have failed, which is why it not running hid the problem for a whole GPU cycle.

## The check that should have caught it

`tests/test_config_kwargs.py` now checks `torch.distributed` free functions against the installed signature, with the torch pin cross-checked against every lab's `uv.lock` — machinery that file already had for transformers/trl/peft. Against the broken tree:

```
FAIL  no rejected kwargs (3 found)
      cifar10_deepspeed.py:217      barrier(... timeout=...)
      train_modern_cifar10.py:231   barrier(... timeout=...)
      probe_device_binding.py:102   barrier(... timeout=...)
```

That file's docstring already warned that validating a version no learner runs "passes while the labs are broken." It now covers the library that bit. No GPU, ~10 seconds.

All 28 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa
