### PR TITLE
fix: Stop reporting a capped CIFAR-10 run as a failure, and harden local_rank

### DIFF
--- a/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
+++ b/01_basics/03_convnet_cifar10/cifar10_deepspeed.py
@@ -692,8 +692,25 @@ def main() -> None:
         print(f"   ✅ Good! Model achieved ≥70% accuracy on CIFAR-10")
     elif quality_score == "fair":
         print(f"   ⚠️  Fair. Model achieved ≥60% accuracy on CIFAR-10")
+    elif args.epochs <= 2 or args.max_steps > 0:
+        # Do not tell a reader their smoke test failed. It did not. This is the
+        # path Clawdeck's "Quick (20 steps)" command takes, and printing
+        # "Poor. Consider training longer or adjusting hyperparameters" under a
+        # "Finished Successfully" banner is how a beginner concludes they broke
+        # something. 20 steps is ~1280 images of 50,000; chance on CIFAR-10 is
+        # 10%, so ~10% here is the expected result, not a failure.
+        # Same rule, and the same fix, as 01_basics/02_convnet.
+        short = (f"--max-steps {args.max_steps}" if args.max_steps > 0
+                 else f"{args.epochs} epoch(s)")
+        print(f"   ⏱️  Below 60%, but this run was capped at {short} -- far too")
+        print(f"      short to be meaningful. This is a PIPELINE smoke test:")
+        print(f"      success means DeepSpeed launched, the data downloaded once,")
+        print(f"      every rank ran, and the loss moved. Accuracy near 10% is")
+        print(f"      chance on CIFAR-10 and is exactly what 20 steps should give.")
+        print(f"      Use --epochs 20 for a number worth reading.")
     else:
-        print(f"   ❌ Poor. Consider training longer or adjusting hyperparameters")
+        print(f"   ❌ Poor after {args.epochs} epochs. Check the learning rate")
+        print(f"      and that the data downloaded correctly.")
 
     # CIFAR-10 specific notes
     print(f"\n💡 Note:")

--- a/01_basics/03_convnet_cifar10/train_modern_cifar10.py
+++ b/01_basics/03_convnet_cifar10/train_modern_cifar10.py
@@ -212,7 +212,15 @@ def main() -> None:
     # cuda:0 on every rank. Both ranks then post to the same GPU and NCCL hangs
     # until the watchdog aborts. This used to sit six lines below the barrier,
     # which was a real hang waiting for the first cold multi-GPU run.
-    device = torch.device(f"cuda:{max(args.local_rank, 0)}")
+    # LOCAL_RANK (environment) first, --local_rank (argv) second. The deepspeed
+    # launcher sets both; torchrun sets only the environment variable, and
+    # falling back to argparse's -1 default would bind EVERY rank to cuda:0 --
+    # which is precisely the hang the device binding below exists to prevent.
+    local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
+    if local_rank < 0:
+        local_rank = max(args.local_rank, 0)
+
+    device = torch.device(f"cuda:{local_rank}")
     if torch.cuda.is_available():
         torch.cuda.set_device(device)
 
@@ -226,7 +234,7 @@ def main() -> None:
         # Explicit device_ids. No timeout= -- torch 2.11, which every lab
         # here locks, does not accept one on barrier(); it lands in 2.13.
         torch.distributed.barrier(
-            device_ids=[max(args.local_rank, 0)] if torch.cuda.is_available() else None,
+            device_ids=[local_rank] if torch.cuda.is_available() else None,
         )
 
     train_x, train_y = as_tensors(True)


### PR DESCRIPTION
Found by actually running the lab on a GPU. This box has one RTX 3080 Ti — I had wrongly said I had no GPU at all, which is why earlier rounds were verified only statically.

## 1. A capped run reported itself as a failure

`--max-steps 20` — the command Clawdeck offers by name as **"Quick (20 steps)"** — printed:

```
🏆 Model Quality Assessment:
   ❌ Poor. Consider training longer or adjusting hyperparameters
🎉 Enhanced CIFAR-10 Training Script Finished Successfully!
```

20 steps is ~1280 of 50,000 images; chance on CIFAR-10 is 10%, so ~10% is the *expected* result. CLAUDE.md already states this rule, and `01_basics/02_convnet` already implements the branch — this lab never got it. Ported.

Now:

```
   ⏱️  Below 60%, but this run was capped at --max-steps 20 -- far too
      short to be meaningful. This is a PIPELINE smoke test: success means
      DeepSpeed launched, the data downloaded once, every rank ran, and the
      loss moved. Accuracy near 10% is chance on CIFAR-10 and is exactly
      what 20 steps should give.
```

## 2. `local_rank` could silently collapse to 0 under torchrun

`train_modern_cifar10.py` derived its device from `args.local_rank`, which argparse defaults to `-1`. The deepspeed launcher sets both argv and `LOCAL_RANK`, so it worked — but under `torchrun`, which sets only the env var, every rank computes `max(-1, 0) = 0` and binds cuda:0. That is the identical hang fixed in #17, one launcher away. Now prefers `LOCAL_RANK`, falls back to argv.

## Verification actually performed

**On hardware** (1× RTX 3080 Ti), both cold with `./data` removed:

| command | result |
|---|---|
| `deepspeed --num_gpus=1 cifar10_deepspeed.py --max-steps 20` | exit 0 |
| `deepspeed --num_gpus=1 train_modern_cifar10.py --epochs 1` | exit 0, **67.77%** test accuracy |

**Multi-rank guard**, executed rather than reasoned about: the shipped `download_cifar10()` was run in two real processes on a real gloo process group with `torchvision` stubbed —

```
rank 0: downloads=2 elapsed=4.0s err=None
rank 1: downloads=0 elapsed=4.0s err=None
PASS  exactly ONE rank downloaded
PASS  it was rank 0
PASS  rank 1 WAITED for rank 0 (barrier held, >1.5s)
PASS  both ranks exited the barrier
```

That also confirms the `barrier(device_ids=...)` signature is valid at the locked torch — the thing that broke in #17.

**Still not covered:** NCCL device binding itself needs two real GPUs. gloo exercises the guard logic and the call signature, not the cuda:0 collision.

All 28 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3aYnvDRbvZ7n78GqH37Qa
